### PR TITLE
Refactors for RSKIP326.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -24,36 +24,32 @@ interface BridgeEvent {
  * Gets Bridge Transactions In a Specified Block Hash Or Block Number
  * @param web3Client Web3 Instance
  * @param blockHashOrBlockNumber The block hash or block number.
- * @param network The network.
  * @returns Array - Array of transaction objects
  */
-export function getBridgeTransactionsInThisBlock(web3Client: Web3, blockHashOrBlockNumber: string | number, network: string): Promise<Array<Transaction>>;
+export function getBridgeTransactionsInThisBlock(web3Client: Web3, blockHashOrBlockNumber: string | number): Promise<Array<Transaction>>;
 
 /**
  * Gets Bridge Transactions In a Specified Range of Blocks
  * @param web3Client Web3 Instance
  * @param startingBlockHashOrBlockNumber The block hash or block number.
  * @param blocksToSearch Number/Amount of blocks to search
- * @param network The network.
  * @returns Array - Array of transaction objects
  */
-export function getBridgeTransactionsSinceThisBlock(web3Client: Web3, startingBlockHashOrBlockNumber: string | number, blocksToSearch: string, network: string): Promise<Array<Transaction>>;
+export function getBridgeTransactionsSinceThisBlock(web3Client: Web3, startingBlockHashOrBlockNumber: string | number, blocksToSearch: string): Promise<Array<Transaction>>;
 
 /**
  * Gets a Single Bridge Transaction Via The Transaction Hash.
  * @param web3Client Web3 Instance
  * @param transactionHash The transaction hash.
- * @param network The network.
  * @returns Object - A transaction object
  */
-export function getBridgeTransactionByTxHash(web3Client: Web3, transactionHash: string, network: string): Promise<Transaction>;
+export function getBridgeTransactionByTxHash(web3Client: Web3, transactionHash: string): Promise<Transaction>;
 
 /**
  * Gets a Bridge Transaction given a bridgeTx: web3TransactionObject and a bridgeTxReceipt: TransactionReceipt.
  * @param web3Client Web3 Instance
  * @param bridgeTx The bridgeTx web3TransactionObject.
  * @param bridgeTxReceipt The bridgeTxReceipt: web3TransactionReceiptObject.
- * @param network The network.
  * @returns Object - A transaction object
  */
-export function decodeBridgeTransaction(web3Client: Web3, bridgeTx: Web3Transaction, bridgeTxReceipt: TransactionReceipt, network: string): Promise<Transaction>;
+export function decodeBridgeTransaction(web3Client: Web3, bridgeTx: Web3Transaction, bridgeTxReceipt: TransactionReceipt): Promise<Transaction>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "bridge-transaction-parser",
-  "version": "0.2.2-beta",
+  "version": "0.3.0-beta",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bridge-transaction-parser",
-      "version": "0.2.2-beta",
+      "version": "0.3.0-beta",
       "license": "MIT",
       "dependencies": {
-        "@rsksmart/rsk-precompiled-abis": "^4.0.2-IRIS",
+        "@rsksmart/rsk-precompiled-abis": "https://github.com/rsksmart/precompiled-abis",
         "bitcoinjs-lib": "^6.0.1"
       },
       "devDependencies": {
@@ -972,9 +972,10 @@
       }
     },
     "node_modules/@rsksmart/rsk-precompiled-abis": {
-      "version": "4.0.2-IRIS",
-      "resolved": "https://registry.npmjs.org/@rsksmart/rsk-precompiled-abis/-/rsk-precompiled-abis-4.0.2-IRIS.tgz",
-      "integrity": "sha512-OsxbGHHrePnOhnC3XhBmvTIRK17gRvz78LCVYjGd32G8u/nA6wNyiCd1dKOUf6pz4a0BIBVBK/l3VoBFaPHcMw==",
+      "version": "6.0.0-HOP",
+      "resolved": "git+ssh://git@github.com/rsksmart/precompiled-abis.git#0cf4e50f83b0ef9499608efb46c2fc3f7bb973cd",
+      "integrity": "sha512-Iyfm/ktIKcma1epsPzPVCsiNNfa7hnldy60bph9JxmbUlLi6g7D6vP0XXsj1ZLIiIbATabByJawVSI+A7Ra6+Q==",
+      "license": "ISC",
       "dependencies": {
         "web3": "^1.3.6"
       }
@@ -8329,9 +8330,9 @@
       "dev": true
     },
     "@rsksmart/rsk-precompiled-abis": {
-      "version": "4.0.2-IRIS",
-      "resolved": "https://registry.npmjs.org/@rsksmart/rsk-precompiled-abis/-/rsk-precompiled-abis-4.0.2-IRIS.tgz",
-      "integrity": "sha512-OsxbGHHrePnOhnC3XhBmvTIRK17gRvz78LCVYjGd32G8u/nA6wNyiCd1dKOUf6pz4a0BIBVBK/l3VoBFaPHcMw==",
+      "version": "git+ssh://git@github.com/rsksmart/precompiled-abis.git#0cf4e50f83b0ef9499608efb46c2fc3f7bb973cd",
+      "integrity": "sha512-Iyfm/ktIKcma1epsPzPVCsiNNfa7hnldy60bph9JxmbUlLi6g7D6vP0XXsj1ZLIiIbATabByJawVSI+A7Ra6+Q==",
+      "from": "@rsksmart/rsk-precompiled-abis@https://github.com/rsksmart/precompiled-abis",
       "requires": {
         "web3": "^1.3.6"
       }

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "bridge-transaction-parser",
-  "version": "0.2.2-beta",
+  "version": "0.3.0-beta",
   "description": "",
   "main": "index.js",
   "scripts": {
     "test": "nyc mocha --timeout 10000"
   },
   "dependencies": {
-    "@rsksmart/rsk-precompiled-abis": "^4.0.2-IRIS",
+    "@rsksmart/rsk-precompiled-abis": "https://github.com/rsksmart/precompiled-abis",
     "bitcoinjs-lib": "^6.0.1"
   },
   "author": "",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -271,7 +271,7 @@ const dataDecodedResults = [
     {
         data: '0x0000000000000000000000000000000000000000000000000000000000000040',
         decoded: {
-            btcDestinationAddress: '0x18b158a6d893d72092ac9b9f8bbb5bf2c22acf76',
+            btcDestinationAddress: 'mhmWxtqj4oAgLkkyZs3impteLcn7csDuMq',
             amount: '1000000'
         }
     },
@@ -305,7 +305,6 @@ const web3ClientStub = {
 
 let transactionParser;
 let sandbox;
-const network = "testnet";
 
 describe('Get Bridge Transaction By Tx Hash', () => {
 
@@ -326,19 +325,19 @@ describe('Get Bridge Transaction By Tx Hash', () => {
     it('Should Fail For Invalid Transaction Hash', async () => {
         const transactionHash = "0x12345";
 
-        await expect(transactionParser.getBridgeTransactionByTxHash(web3ClientStub, transactionHash, network))
+        await expect(transactionParser.getBridgeTransactionByTxHash(web3ClientStub, transactionHash))
             .to.be.rejectedWith('Hash must be of length 66 starting with "0x"');
     });
 
     it('Should return empty for non Bridge transaction hash', async () => {
         const txReceipt = txReceiptsStub[0];
 
-        await expect(transactionParser.getBridgeTransactionByTxHash(web3ClientStub, txReceipt.transactionHash, network)).to.be.empty;
+        await expect(transactionParser.getBridgeTransactionByTxHash(web3ClientStub, txReceipt.transactionHash)).to.be.empty;
     });
 
     it('Should Verify And Return Bridge Transaction From Tx Hash', async () => {
         let txReceipt = txReceiptsStub[4];
-        let result = await transactionParser.getBridgeTransactionByTxHash(web3ClientStub, txReceipt.transactionHash, network);
+        let result = await transactionParser.getBridgeTransactionByTxHash(web3ClientStub, txReceipt.transactionHash);
 
         assert.equal(result.txHash, txReceipt.transactionHash);
         assert.equal(result.blockNumber, txReceipt.blockNumber);
@@ -384,27 +383,27 @@ describe('Get Bridge Transactions From Single Block', () => {
     it('Should Fail For Invalid Block Number', async () => {
         const blockNumber = 0;
 
-        await expect(transactionParser.getBridgeTransactionsInThisBlock(web3ClientStub, blockNumber, network))
+        await expect(transactionParser.getBridgeTransactionsInThisBlock(web3ClientStub, blockNumber))
             .to.be.rejectedWith('Block number must be greater than 0');
     });
 
     it('Should fail for inexisting block number', async () => {
         const blockNumber = 1000000;
 
-        await expect(transactionParser.getBridgeTransactionsInThisBlock(web3ClientStub, blockNumber, network))
+        await expect(transactionParser.getBridgeTransactionsInThisBlock(web3ClientStub, blockNumber))
             .to.be.rejectedWith(`Block ${blockNumber} not found`);
     });
 
     it('Should return empty for block without Bridge transactions', async () => {
         let block = blocksStub[1];
-        let result = await transactionParser.getBridgeTransactionsInThisBlock(web3ClientStub, block.number, network);
+        let result = await transactionParser.getBridgeTransactionsInThisBlock(web3ClientStub, block.number);
 
         assert.lengthOf(result, 0);
     });
 
     it('Should Verify And Return Bridge Transactions From Block', async () => {
         let block = blocksStub[0];
-        let result = await transactionParser.getBridgeTransactionsInThisBlock(web3ClientStub, block.number, network);
+        let result = await transactionParser.getBridgeTransactionsInThisBlock(web3ClientStub, block.number);
 
         assert.lengthOf(result, 2);
         assert.equal(result[0].txHash, block.transactions[0]);
@@ -431,19 +430,19 @@ describe('Get Bridge Transactions From Multiple Blocks', () => {
     it('Should Fail For Invalid Start Block Number', async () => {
         let startingBlock = 0;
         let blocksToSearch = 5;
-        await expect(transactionParser.getBridgeTransactionsSinceThisBlock(web3ClientStub, startingBlock, blocksToSearch, network))
+        await expect(transactionParser.getBridgeTransactionsSinceThisBlock(web3ClientStub, startingBlock, blocksToSearch))
             .to.be.rejectedWith('Block number must be greater than 0');
 
         startingBlock = 3701647;
         blocksToSearch = 101;
-        await expect(transactionParser.getBridgeTransactionsSinceThisBlock(web3ClientStub, startingBlock, blocksToSearch, network))
+        await expect(transactionParser.getBridgeTransactionsSinceThisBlock(web3ClientStub, startingBlock, blocksToSearch))
             .to.be.rejectedWith('blocksToSearch must be greater than 0 or less than 100');
     });
 
     it('Should Verify And Return Bridge Transactions From Blocks', async () => {
         const startingBlockNumber = 1001;
         const blocksToSearch = 3;
-        let result = await transactionParser.getBridgeTransactionsSinceThisBlock(web3ClientStub, startingBlockNumber, blocksToSearch, network);
+        let result = await transactionParser.getBridgeTransactionsSinceThisBlock(web3ClientStub, startingBlockNumber, blocksToSearch);
 
         assert.lengthOf(result, 3);
         assert.equal(result[0].txHash, blocksStub[0].transactions[0]);
@@ -472,7 +471,7 @@ describe('Gets a Bridge Transaction given a bridgeTx: web3TransactionObject and 
         const bridgeTx = web3ClientStub.eth.getTransaction("0x7a3c39f59e1f2c624602c9b54c28155a251963ec878049c0f78a7d281b2e3b87");
         const bridgeTxReceipt = web3ClientStub.eth.getTransactionReceipt("0x112439355294e02096078c3b77cb12546fe79d284f46d478b3584873c2bacb8b");
 
-        await expect(transactionParser.decodeBridgeTransaction(web3ClientStub, bridgeTx, bridgeTxReceipt, network))
+        await expect(transactionParser.decodeBridgeTransaction(web3ClientStub, bridgeTx, bridgeTxReceipt))
           .to.be.rejectedWith(`Given bridgeTx(${bridgeTx.hash}) and bridgeTxReceipt(${bridgeTxReceipt.transactionHash}) 
         should belong to the same transaction.`);
     });
@@ -481,7 +480,7 @@ describe('Gets a Bridge Transaction given a bridgeTx: web3TransactionObject and 
         const bridgeTx = web3ClientStub.eth.getTransaction("0x6547e88a30d1b43c6fbea07fa7443dfeb697d076495c3e4fc56ebf40228e0431");
         const nonBridgeTxReceipt = web3ClientStub.eth.getTransactionReceipt("0x6547e88a30d1b43c6fbea07fa7443dfeb697d076495c3e4fc56ebf40228e0431");
 
-        await expect(transactionParser.decodeBridgeTransaction(web3ClientStub, bridgeTx, nonBridgeTxReceipt, network))
+        await expect(transactionParser.decodeBridgeTransaction(web3ClientStub, bridgeTx, nonBridgeTxReceipt))
           .to.be.rejectedWith(`Given bridgeTxReceipt is not a bridge transaction`);
     });
 
@@ -490,7 +489,7 @@ describe('Gets a Bridge Transaction given a bridgeTx: web3TransactionObject and 
         const bridgeTx = web3ClientStub.eth.getTransaction("0x73a4d1592c5e922c2c6820985982d2715538717e4b4b52502685bc4c924300b7");
         const bridgeTxReceipt = web3ClientStub.eth.getTransactionReceipt("0x73a4d1592c5e922c2c6820985982d2715538717e4b4b52502685bc4c924300b7");
 
-        const transaction = await transactionParser.decodeBridgeTransaction(web3ClientStub, bridgeTx, bridgeTxReceipt, network)
+        const transaction = await transactionParser.decodeBridgeTransaction(web3ClientStub, bridgeTx, bridgeTxReceipt)
 
         assert.equal(transaction.txHash, bridgeTxReceipt.transactionHash);
         assert.equal(transaction.blockNumber, bridgeTxReceipt.blockNumber);

--- a/tool/bridge-transaction-decoder.js
+++ b/tool/bridge-transaction-decoder.js
@@ -9,7 +9,7 @@ const blockTransactionParser = require('../index');
 
     const bridgeTx = JSON.parse(process.argv[3]);
     const bridgeTxReceipt = JSON.parse(process.argv[4]);
-    const transaction = await blockTransactionParser.decodeBridgeTransaction(web3Client, bridgeTx, bridgeTxReceipt, network)
+    const transaction = await blockTransactionParser.decodeBridgeTransaction(web3Client, bridgeTx, bridgeTxReceipt)
 
     if (transaction) {
       console.log(JSON.stringify(transaction, null, 2));

--- a/tool/bridge-transaction-txHash.js
+++ b/tool/bridge-transaction-txHash.js
@@ -8,7 +8,7 @@ const blockTransactionParser = require('../index');
         const web3Client = new Web3(networkParser(network));
 
         const transactionHash = process.argv[3]; // Format: 0x73a4d1592c5e922c2c6820985982d2715538717e4b4b52502685bc4c924300b7
-        const transaction = await blockTransactionParser.getBridgeTransactionByTxHash(web3Client, transactionHash, network)
+        const transaction = await blockTransactionParser.getBridgeTransactionByTxHash(web3Client, transactionHash)
         
         if (transaction) {
             console.log(JSON.stringify(transaction, null, 2));

--- a/tool/bridge-transactions-multiple-blocks.js
+++ b/tool/bridge-transactions-multiple-blocks.js
@@ -11,7 +11,7 @@ const blockTransactionParser = require('../index');
         const blocksToSearch = process.argv[4]; // Input should be between 1 and 100
         
         console.log("Searching...");
-        const transactions = await blockTransactionParser.getBridgeTransactionsSinceThisBlock(web3Client, startingBlock, blocksToSearch, network);
+        const transactions = await blockTransactionParser.getBridgeTransactionsSinceThisBlock(web3Client, startingBlock, blocksToSearch);
         
         if (transactions.length) {
             console.log(JSON.stringify(transactions, null, 2));

--- a/tool/bridge-transactions-single-block.js
+++ b/tool/bridge-transactions-single-block.js
@@ -9,7 +9,7 @@ const blockTransactionParser = require('../index');
 
         const blockNumber = process.argv[3];
 
-        const blockTransactions = await blockTransactionParser.getBridgeTransactionsInThisBlock(web3Client, blockNumber, network);
+        const blockTransactions = await blockTransactionParser.getBridgeTransactionsInThisBlock(web3Client, blockNumber);
         if (blockTransactions.length) {
             console.log(JSON.stringify(blockTransactions, null, 2));
         } else {

--- a/utils.js
+++ b/utils.js
@@ -1,20 +1,3 @@
-const bitcoin = require("bitcoinjs-lib");
-
-const btcAddressFromPublicKeyHash = (pubKeyHash, network) => {
-    return bitcoin.payments.p2pkh({
-        hash: Buffer.from(stripHexPrefix(pubKeyHash), "hex"),
-        network: getNetwork(network),
-    }).address;
-};
-
-const getNetwork = (network) => {
-    return network === "mainnet" ? bitcoin.networks.bitcoin : bitcoin.networks.testnet;
-};
-
-const stripHexPrefix = (str) => {
-    return typeof str === "string" && str.startsWith("0x") ? str.slice(2) : str;
-};
-
 const verifyHashOrBlockNumber = (blockHashOrBlockNumber) => {
     if (typeof blockHashOrBlockNumber === "string" &&
         blockHashOrBlockNumber.indexOf("0x") === 0 &&
@@ -26,6 +9,5 @@ const verifyHashOrBlockNumber = (blockHashOrBlockNumber) => {
 };
 
 module.exports = {
-    btcAddressFromPublicKeyHash,
     verifyHashOrBlockNumber,
 };


### PR DESCRIPTION
Refactors for RSKIP326.
Removed unnecessary util functions to convert from hash160 to base58 because it is no longer needed with RSKIP326.
Updated test.