### PR TITLE
Changed Args Data Type From Map To Object

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is a beta version until audited by the security team. Any comments or sugge
 ## Run console tool:
 - `node tool/bridge-transaction-txHash.js $network $txHash`
 - `node tool/bridge-transactions-single-block.js $network $blockHashOrBlockNumber`
-- `node tool/bridge-transactions-multiple-block.js $network $startingBlockHashOrBlockNumber $blocksToSearch`
+- `node tool/bridge-transactions-multiple-blocks.js $network $startingBlockHashOrBlockNumber $blocksToSearch`
 - `node tool/bridge-transaction-decoder.js $network $bridgeTx $bridgeTxReceipt`
 
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,13 +11,13 @@ interface Transaction {
 interface BridgeMethod {
     name: string,
     signature: string,
-    arguments: Map<string, unknown>
+    arguments: {}
 }
 
 interface BridgeEvent {
     name: string,
     signature: string,
-    arguments: Map<string, unknown>
+    arguments: {}
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -84,11 +84,10 @@ const decodeBridgeMethodParameters = (web3Client, methodName, data) => {
     let dataDecoded = web3Client.eth.abi.decodeParameters(abi.inputs, argumentsData);
 
     // TODO: the parsing of the arguments is not tested
-    let args = new Map();
+    let args = {};
     for (let input of abi.inputs) {
-        args.set(input.name, dataDecoded[input.name]);
+        args[input.name] = dataDecoded[input.name];
     }
-
     return args;
 }
 
@@ -111,9 +110,8 @@ const decodeLogs = (web3Client, tx, bridge) => {
         let bridgeEvent = bridge._jsonInterface.find(i => i.signature === txLog.topics[0]);
         
         if (bridgeEvent) {
-            let args = new Map();
+            let args = {};
             let dataDecoded = web3Client.eth.abi.decodeParameters(bridgeEvent.inputs.filter(i => !i.indexed), txLog.data);
-
             let topicIndex = 1;
             for (let input of bridgeEvent.inputs) {
                 let value;
@@ -123,7 +121,7 @@ const decodeLogs = (web3Client, tx, bridge) => {
                 } else {
                     value = dataDecoded[input.name];
                 }
-                args.set(input.name, value);
+                args[input.name] = value;
             }
             events.push(new BridgeEvent(bridgeEvent.name, bridgeEvent.signature, args));
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bridge-transaction-parser",
-  "version": "0.3.0-beta",
+  "version": "0.3.1-beta",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bridge-transaction-parser",
-      "version": "0.3.0-beta",
+      "version": "0.3.1-beta",
       "license": "MIT",
       "dependencies": {
         "@rsksmart/rsk-precompiled-abis": "https://github.com/rsksmart/precompiled-abis",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bridge-transaction-parser",
-  "version": "0.3.0-beta",
+  "version": "0.3.1-beta",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -348,19 +348,19 @@ describe('Get Bridge Transaction By Tx Hash', () => {
         assert.lengthOf(result.events, 3);
         assert.equal(result.events[0].name, "update_collections");
         assert.equal(result.events[0].signature, "0x1069152f4f916cbf155ee32a695d92258481944edb5b6fd649718fc1b43e515e");
-        assert.equal(result.events[0].arguments.get('sender'), '0xFE90f02331DdF62cb50F5650Dca554b47B37c471');
+        assert.equal(result.events[0].arguments.sender, '0xFE90f02331DdF62cb50F5650Dca554b47B37c471');
 
         assert.equal(result.events[1].name, "release_requested");
         assert.equal(result.events[1].signature, "0x7a7c29481528ac8c2b2e93aee658fddd4dc15304fa723a5c2b88514557bcc790");
-        assert.equal(result.events[1].arguments.get('rskTxHash'), "0x6b735fe7af1819082404d3d05133ceaba3ebfc400cdfd621261285e6b092371f");
-        assert.equal(result.events[1].arguments.get('btcTxHash'), "0x7cbbf9d911d8e76b2a3a4b02a430b39b0b5c3b95f3ee2ca5df1483980d960e0b");
-        assert.equal(result.events[1].arguments.get('amount'), "1011610");
+        assert.equal(result.events[1].arguments.rskTxHash, "0x6b735fe7af1819082404d3d05133ceaba3ebfc400cdfd621261285e6b092371f");
+        assert.equal(result.events[1].arguments.btcTxHash, "0x7cbbf9d911d8e76b2a3a4b02a430b39b0b5c3b95f3ee2ca5df1483980d960e0b");
+        assert.equal(result.events[1].arguments.amount, "1011610");
 
         assert.equal(result.events[2].name, "release_request_received");
         assert.equal(result.events[2].signature, "0x8e04e2f2c246a91202761c435d6a4971bdc7af0617f0c739d900ecd12a6d7266");
-        assert.equal(result.events[2].arguments.get('sender'), "0x75d7B75612Ed7A0eDc70ceCED86A9701E8D07D6a");
-        assert.equal(result.events[2].arguments.get('btcDestinationAddress'), "mhmWxtqj4oAgLkkyZs3impteLcn7csDuMq");
-        assert.equal(result.events[2].arguments.get('amount'), "1000000");
+        assert.equal(result.events[2].arguments.sender, "0x75d7B75612Ed7A0eDc70ceCED86A9701E8D07D6a");
+        assert.equal(result.events[2].arguments.btcDestinationAddress, "mhmWxtqj4oAgLkkyZs3impteLcn7csDuMq");
+        assert.equal(result.events[2].arguments.amount, "1000000");
     });
 })
 
@@ -500,18 +500,18 @@ describe('Gets a Bridge Transaction given a bridgeTx: web3TransactionObject and 
         assert.lengthOf(transaction.events, 3);
         assert.equal(transaction.events[0].name, "update_collections");
         assert.equal(transaction.events[0].signature, "0x1069152f4f916cbf155ee32a695d92258481944edb5b6fd649718fc1b43e515e");
-        assert.equal(transaction.events[0].arguments.get('sender'), '0xFE90f02331DdF62cb50F5650Dca554b47B37c471');
+        assert.equal(transaction.events[0].arguments.sender, '0xFE90f02331DdF62cb50F5650Dca554b47B37c471');
 
         assert.equal(transaction.events[1].name, "release_requested");
         assert.equal(transaction.events[1].signature, "0x7a7c29481528ac8c2b2e93aee658fddd4dc15304fa723a5c2b88514557bcc790");
-        assert.equal(transaction.events[1].arguments.get('rskTxHash'), "0x6b735fe7af1819082404d3d05133ceaba3ebfc400cdfd621261285e6b092371f");
-        assert.equal(transaction.events[1].arguments.get('btcTxHash'), "0x7cbbf9d911d8e76b2a3a4b02a430b39b0b5c3b95f3ee2ca5df1483980d960e0b");
-        assert.equal(transaction.events[1].arguments.get('amount'), "1011610");
+        assert.equal(transaction.events[1].arguments.rskTxHash, "0x6b735fe7af1819082404d3d05133ceaba3ebfc400cdfd621261285e6b092371f");
+        assert.equal(transaction.events[1].arguments.btcTxHash, "0x7cbbf9d911d8e76b2a3a4b02a430b39b0b5c3b95f3ee2ca5df1483980d960e0b");
+        assert.equal(transaction.events[1].arguments.amount, "1011610");
 
         assert.equal(transaction.events[2].name, "release_request_received");
         assert.equal(transaction.events[2].signature, "0x8e04e2f2c246a91202761c435d6a4971bdc7af0617f0c739d900ecd12a6d7266");
-        assert.equal(transaction.events[2].arguments.get('sender'), "0x75d7B75612Ed7A0eDc70ceCED86A9701E8D07D6a");
-        assert.equal(transaction.events[2].arguments.get('btcDestinationAddress'), "mhmWxtqj4oAgLkkyZs3impteLcn7csDuMq");
-        assert.equal(transaction.events[2].arguments.get('amount'), "1000000");
+        assert.equal(transaction.events[2].arguments.sender, "0x75d7B75612Ed7A0eDc70ceCED86A9701E8D07D6a");
+        assert.equal(transaction.events[2].arguments.btcDestinationAddress, "mhmWxtqj4oAgLkkyZs3impteLcn7csDuMq");
+        assert.equal(transaction.events[2].arguments.amount, "1000000");
     });
 })


### PR DESCRIPTION
This PR fixes some minor issues using map data type. Using Object data type helps print the transactions properly while using the library.