### PR TITLE
Only emitting the stopped event if the monitor was still active and w…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rsksmart/bridge-transaction-parser",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rsksmart/bridge-transaction-parser",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "@rsksmart/rsk-precompiled-abis": "^5.0.0-FINGERROOT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/bridge-transaction-parser",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A tool to find interactions with the Bridge on Rootstock",
   "main": "index.js",
   "scripts": {

--- a/tool/live-monitor/live-monitor.js
+++ b/tool/live-monitor/live-monitor.js
@@ -247,15 +247,16 @@ class LiveMonitor extends EventEmitter {
 
     stop() {
         try {
-            this.isStarted = false;
-            clearTimeout(this.timer);
-            this.timer = null;
-            this.emit(MONITOR_EVENTS.stopped, 'Live monitor stopped');
+            if(this.isStarted || this.timer !== null) {
+                this.isStarted = false;
+                clearTimeout(this.timer);
+                this.timer = null;
+                this.emit(MONITOR_EVENTS.stopped, 'Live monitor stopped');
+            }
         } catch(error) {
             this.emit(MONITOR_EVENTS.error, `There was an error trying to stop the live monitor: ${error.message}`);
             console.error(error);
         }
-
         return this;
     }
 


### PR DESCRIPTION
Only emitting the stopped event if the monitor was still active and was stopped now.

Before, when the `monitor.stop()` was called multiple times, it always emmited the `stopped` event even though it was already stopped. There's no need to keep sending the `stopped` event if the monitor is already stopped. So, this pr is ignoring any `stop()` call if the monitor is already stopped.
