### PR TITLE
Fixes toBlock logic to only setup this.toBlock when params.toBlock wa…

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ You can also specify a `toBlock` parameter.
 
 If `toBlock` param is not provided, then the tool will continue to synch with new blocks.
 
+If `toBlock` param is provided and the monitor reaches that block number, then the monitor will emit the `toBlockReached` event and stop.
+
 ### Samples with the exported `monitor` function
 
 ```js

--- a/tool/live-monitor/live-monitor-utils.js
+++ b/tool/live-monitor/live-monitor-utils.js
@@ -8,6 +8,7 @@ const MONITOR_EVENTS = {
     stopped: 'stopped',
     started: 'started',
     reset: 'reset',
+    toBlockReached: 'toBlockReached',
 };
 
 const defaultParamsValues = {

--- a/tool/live-monitor/live-monitor.js
+++ b/tool/live-monitor/live-monitor.js
@@ -123,8 +123,8 @@ class LiveMonitor extends EventEmitter {
             }
 
             if(this.toBlock && this.toBlock !== -1 && this.currentBlockNumber >= this.toBlock) {
-                this.emit(MONITOR_EVENTS.latestBlockReached, 'To block number reached. Exiting...');
-                this.isStarted = false;
+                this.emit(MONITOR_EVENTS.toBlockReached, 'To block number reached. Stopping monitor...');
+                this.stop();
                 return;
             }
 
@@ -208,12 +208,14 @@ class LiveMonitor extends EventEmitter {
                         this.currentBlockNumber = parseInt(this.currentBlockNumber);
                     }
 
-                    if(this.params.toBlock === 'latest') {
-                        this.toBlock = this.latestBlockNumber;
-                    } else {
-                        this.toBlock = Number(this.params.toBlock);
+                    if(this.params.toBlock) {
+                        if(this.params.toBlock === 'latest') {
+                            this.toBlock = this.latestBlockNumber;
+                        } else {
+                            this.toBlock = Number(this.params.toBlock);
+                        }
                     }
-
+                    
                     if(this.currentBlockNumber < 0) {
                         // If the block number is negative, it will be interpreted as the number of blocks before the latest block
                         this.currentBlockNumber = this.latestBlockNumber + this.currentBlockNumber;


### PR DESCRIPTION
The `this.toBlock` property was being set even when the `params.toBlock` was not being passed. Causing the monitor to stop at the latest block.

Also, the `this.latestBlockNumber` was not being updated, causing the monitor to stop at the latest recorded block number during monitoring setup.

Simplified the code by moving the `this.check()` call to the finally block, to avoid duplication.

Added a new `toBlockReached` event to distinguish from the `latestBlockReached` event.