### PR TITLE
Adds pegout tracker tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ node tool/pegout-tracker/cli-pegout-tracker.js --pegoutTxHash=0xa6397d264cae18a1
 
 If no `--network` is provided, `mainnet` will be the default.
 
-Note: Before using the tool to find a pegout information, make sure the pegout has already been completed. Because the tool will try skiping blocks, will go to future blocks based on `nextPegoutHeight` and the amount of confirmations required for each network. If it tries to go to a non existing block, then the tool will throw an error.
+Note: the pegout tracker tool skips bloks 2 times: 1, it skips the blocks in between the original pegout request block and the `nextPegoutCreationHeight`, becase we know there won't be any information about that pegout in between these ranges. 2, when the pagout is waiting for confirmations, it will skip to when the pegout will have enough confirmations to start searching for the `add_signature` events. If the `nextPegoutCreationHeight` and the future block when the pegout will have enough confirmation is greater than the latest block, then the tool will start searching from the latest block.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,102 @@ const newParams = {
 monitor.reset(newParams);
 
 ```
+
+## Pegout Tracker
+
+You can use the `tool/pegout-tracker/pegout-tracker.js` to track a pegout request, from start to finish.
+
+To use it, you only need a pegout transaction hash and a network. Then, you can call `PegoutTarcker::trackPegout` and subscribe to the `PEGOUT_TRACKER_EVENTS.pegoutStagesFound` event, like this:
+
+```js
+const util = require('util');
+const PegoutTracker = require('./pegout-tracker');
+const { PEGOUT_TRACKER_EVENTS } = require('./pegout-tracker-utils');
+
+const pegoutTxHash = '0x...'; // Needs to be the tx hash that the user got when sending funds to the bridge to request a pegout.
+const network = 'mainnet'; // Can be 'mainnet' or 'testnet'
+
+const pegoutTracker = new PegoutTracker();
+
+// This will be executed once all the pegout information has been gathered.
+pegoutTracker.on(PEGOUT_TRACKER_EVENTS.pegoutStagesFound, bridgeTxDetails => {
+    console.info('pegoutStagesFound: ')
+    console.info(util.inspect(bridgeTxDetails, {depth: null, colors: true}));
+});
+
+pegoutTracker.trackPegout(pegoutTxHash, network);
+
+```
+
+If no `network` is provided, `mainnet` will be the default.
+
+Or, you can subscribe to all the stages events, like this:
+
+```js
+
+const util = require('util');
+const PegoutTracker = require('./pegout-tracker');
+const { PEGOUT_TRACKER_EVENTS } = require('./pegout-tracker-utils');
+
+const pegoutTxHash = '0x...'; // Needs to be the tx hash that the user got when sending funds to the bridge to request a pegout.
+const network = 'mainnet'; // Can be 'mainnet' or 'testnet'
+
+const pegoutTracker = new PegoutTracker();
+
+pegoutTracker.on(PEGOUT_TRACKER_EVENTS.releaseRequestRejectedEventFound, bridgeTxDetails => {
+    console.info('Pegout stage 1 (pegout request rejected) transaction found: ');
+    console.info(util.inspect(bridgeTxDetails, {depth: null, colors: true}));
+});
+
+pegoutTracker.on(PEGOUT_TRACKER_EVENTS.releaseRequestReceivedEventFound, bridgeTxDetails => {
+    console.info('Pegout stage 1 (pegout request) transaction found: ');
+    console.info(util.inspect(bridgeTxDetails, {depth: null, colors: true}));
+});
+
+pegoutTracker.on(PEGOUT_TRACKER_EVENTS.releaseRequestedEventFound, bridgeTxDetails => {
+    console.info('Pegout stage 2 (pegout created) transaction found: ');
+    console.info(util.inspect(bridgeTxDetails, {depth: null, colors: true}));
+});
+
+pegoutTracker.on(PEGOUT_TRACKER_EVENTS.batchPegoutCreatedEventFound, bridgeTxDetails => {
+    console.info('Pegout stage 2 (batch pegout created) transaction found: ');
+    console.info(util.inspect(bridgeTxDetails, {depth: null, colors: true}));
+});
+
+pegoutTracker.on(PEGOUT_TRACKER_EVENTS.pegoutConfirmedEventFound, bridgeTxDetails => {
+    console.info('Pegout stage 3 (confirmations) transaction found: ');
+    console.info(util.inspect(bridgeTxDetails, {depth: null, colors: true}));
+});
+
+pegoutTracker.on(PEGOUT_TRACKER_EVENTS.addSignatureEventFound, bridgeTxDetails => {
+    console.info('Pegout stage 4 (signatures) transaction found: ');
+    console.info(util.inspect(bridgeTxDetails, {depth: null, colors: true}));
+});
+
+pegoutTracker.on(PEGOUT_TRACKER_EVENTS.releaseBtcEventFound, bridgeTxDetails => {
+    console.info('Pegout stage 4 (release) transaction found: ');
+    console.info(util.inspect(bridgeTxDetails, {depth: null, colors: true}));
+});
+
+pegoutTracker.on(PEGOUT_TRACKER_EVENTS.pegoutStagesFound, bridgeTxDetails => {
+    console.info('pegoutStagesFound: ')
+    console.info(util.inspect(bridgeTxDetails, {depth: null, colors: true}));
+});
+
+pegoutTracker.trackPegout(pegoutTxHash, network);
+
+```
+
+Or, you can use the `cli-pegout-tracker` tool, like this:
+
+```sh
+node tool/pegout-tracker/cli-pegout-tracker.js --pegoutTxHash=0xa6397d264cae18a1b3ace7a33b24580fd759c075ee27feb7eb9e6d19f50ff3ee --network=mainnet
+```
+
+If no `--network` is provided, `mainnet` will be the default.
+
+Note: Before using the tool to find a pegout information, make sure the pegout has already been completed. Because the tool will try skiping blocks, will go to future blocks based on `nextPegoutHeight` and the amount of confirmations required for each network. If it tries to go to a non existing block, then the tool will throw an error.
+
 ## Contributing
 
 Any comments or suggestions feel free to contribute or reach out at our [open slack](https://dev.rootstock.io//slack).

--- a/README.md
+++ b/README.md
@@ -315,6 +315,15 @@ node tool/pegout-tracker/cli-pegout-tracker.js --pegoutTxHash=0xa6397d264cae18a1
 
 If no `--network` is provided, `mainnet` will be the default.
 
+To provide a custom network url, simply send `--network=http:...` or `--network=https:...`, like this:
+
+```sh
+node tool/pegout-tracker/cli-pegout-tracker.js --pegoutTxHash=0x78c2245bcf1953af4c8090dcd45f11c9e8dc20c4a2531370551b7283a02cf4c8 --network=http://127.0.0.1:4450 --requiredConfirmations=3
+```
+Notice that the value of a custom network has to start with either `http` or `https`. Otherwise, it will throw an error.
+
+The `--requiredConfirmations` param is required for custom networks, because custom networks can have a different value for the required confirmations. Not providing it while passing a network starting with `http` will cause an error.
+
 Note: the pegout tracker tool skips bloks 2 times: 1, it skips the blocks in between the original pegout request block and the `nextPegoutCreationHeight`, becase we know there won't be any information about that pegout in between these ranges. 2, when the pagout is waiting for confirmations, it will skip to when the pegout will have enough confirmations to start searching for the `add_signature` events. If the `nextPegoutCreationHeight` and the future block when the pegout will have enough confirmation is greater than the latest block, then the tool will start searching from the latest block.
 
 ## Contributing

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rsksmart/bridge-transaction-parser",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rsksmart/bridge-transaction-parser",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@rsksmart/rsk-precompiled-abis": "^5.0.0-FINGERROOT"
@@ -44,15 +44,87 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
-      "integrity": "sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+      "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.22.5"
+        "@babel/highlight": "^7.23.4",
+        "chalk": "^2.4.2"
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
+    },
+    "node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@babel/compat-data": {
@@ -95,12 +167,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.22.9",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.9.tgz",
-      "integrity": "sha512-KtLMbmicyuK2Ak/FTCJVbDnkN1SlT8/kceFTiuDiiRUUSMnHMidxSCdG4ndkTOHHpoomWe/4xkvHkEOncwjYIw==",
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
+      "integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.22.5",
+        "@babel/types": "^7.23.6",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -129,22 +201,22 @@
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.5.tgz",
-      "integrity": "sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz",
-      "integrity": "sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.22.5",
-        "@babel/types": "^7.22.5"
+        "@babel/template": "^7.22.15",
+        "@babel/types": "^7.23.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -218,18 +290,18 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
+      "integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
-      "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -259,13 +331,13 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.5.tgz",
-      "integrity": "sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
+      "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.22.5",
-        "chalk": "^2.0.0",
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "chalk": "^2.4.2",
         "js-tokens": "^4.0.0"
       },
       "engines": {
@@ -344,9 +416,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.22.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.7.tgz",
-      "integrity": "sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==",
+      "version": "7.24.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.0.tgz",
+      "integrity": "sha512-QuP/FxEAzMSjXygs8v4N9dvdXzEHN4W1oF3PxuWAtPo08UdM17u89RDMgjLn/mlc56iM0HlLmVkO/wgR+rDgHg==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -356,34 +428,34 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.5.tgz",
-      "integrity": "sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==",
+      "version": "7.24.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.0.tgz",
+      "integrity": "sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.22.5",
-        "@babel/parser": "^7.22.5",
-        "@babel/types": "^7.22.5"
+        "@babel/code-frame": "^7.23.5",
+        "@babel/parser": "^7.24.0",
+        "@babel/types": "^7.24.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.22.8",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.8.tgz",
-      "integrity": "sha512-y6LPR+wpM2I3qJrsheCTwhIinzkETbplIgPBbwvqPKc+uljeA5gP+3nP8irdYt1mjQaDnlIcG+dw8OjAco4GXw==",
+      "version": "7.24.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.0.tgz",
+      "integrity": "sha512-HfuJlI8qq3dEDmNU5ChzzpZRWq+oxCZQyMzIMEqLho+AQnhMnKQUzH6ydo3RBl/YjPCuk68Y6s0Gx0AeyULiWw==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.22.5",
-        "@babel/generator": "^7.22.7",
-        "@babel/helper-environment-visitor": "^7.22.5",
-        "@babel/helper-function-name": "^7.22.5",
+        "@babel/code-frame": "^7.23.5",
+        "@babel/generator": "^7.23.6",
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.22.7",
-        "@babel/types": "^7.22.5",
-        "debug": "^4.1.0",
+        "@babel/parser": "^7.24.0",
+        "@babel/types": "^7.24.0",
+        "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
       "engines": {
@@ -391,13 +463,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.5.tgz",
-      "integrity": "sha512-zo3MIHGOkPOfoRXitsgHLjEXmlDaD/5KU1Uzuc9GNiZPhSqVxVRtxuPaSBZDsYZ9qV88AjtMtWW7ww98loJ9KA==",
+      "version": "7.24.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.0.tgz",
+      "integrity": "sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-string-parser": "^7.22.5",
-        "@babel/helper-validator-identifier": "^7.22.5",
+        "@babel/helper-string-parser": "^7.23.4",
+        "@babel/helper-validator-identifier": "^7.22.20",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -496,23 +568,49 @@
       }
     },
     "node_modules/@ethereumjs/common": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-2.5.0.tgz",
-      "integrity": "sha512-DEHjW6e38o+JmB/NO3GZBpW4lpaiBpkFgXF6jLcJ6gETBYpEyaA5nTimsWBUJR3Vmtm/didUEbNjajskugZORg==",
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-2.6.5.tgz",
+      "integrity": "sha512-lRyVQOeCDaIVtgfbowla32pzeDv2Obr8oR8Put5RdUBNRGr1VGPGQNGP6elWIpgK3YdpzqTOh4GyUGOureVeeA==",
       "dev": true,
       "dependencies": {
         "crc-32": "^1.2.0",
-        "ethereumjs-util": "^7.1.1"
+        "ethereumjs-util": "^7.1.5"
+      }
+    },
+    "node_modules/@ethereumjs/rlp": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/rlp/-/rlp-4.0.1.tgz",
+      "integrity": "sha512-tqsQiBQDQdmPWE1xkkBq4rlSW5QZpLOUJ5RJh2/9fug+q9tnUhuZoVLk7s0scUIKTOzEtR72DFBXI4WiZcMpvw==",
+      "dev": true,
+      "bin": {
+        "rlp": "bin/rlp"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@ethereumjs/tx": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-3.3.2.tgz",
-      "integrity": "sha512-6AaJhwg4ucmwTvw/1qLaZUX5miWrwZ4nLOUsKyb/HtzS3BMw/CasKhdi1ims9mBKeK9sOJCH4qGKOBGyJCeeog==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-3.5.2.tgz",
+      "integrity": "sha512-gQDNJWKrSDGu2w7w0PzVXVBNMzb7wwdDOmOqczmhNjqFxFuIbhVJDwiGEnxFNC2/b8ifcZzY7MLcluizohRzNw==",
       "dev": true,
       "dependencies": {
-        "@ethereumjs/common": "^2.5.0",
-        "ethereumjs-util": "^7.1.2"
+        "@ethereumjs/common": "^2.6.4",
+        "ethereumjs-util": "^7.1.5"
+      }
+    },
+    "node_modules/@ethereumjs/util": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/util/-/util-8.1.0.tgz",
+      "integrity": "sha512-zQ0IqbdX8FZ9aw11vP+dZkKDkS+kgIvQPHnSAXzP9pLu+Rfu3D3XEeLbicvoXJTYnhZiPmsZUxgdzXwNKxRPbA==",
+      "dev": true,
+      "dependencies": {
+        "@ethereumjs/rlp": "^4.0.1",
+        "ethereum-cryptography": "^2.0.0",
+        "micro-ftch": "^0.3.1"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@ethersproject/abi": {
@@ -1114,10 +1212,70 @@
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
       "dev": true
     },
+    "node_modules/@noble/curves": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.3.0.tgz",
+      "integrity": "sha512-t01iSXPuN+Eqzb4eBX0S5oubSqXbK/xXa1Ne18Hj8f9pStxztHCE2gfboSp/dZRLSqfuLpRK2nDXDK+W9puocA==",
+      "dev": true,
+      "dependencies": {
+        "@noble/hashes": "1.3.3"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
+      "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@rsksmart/rsk-precompiled-abis": {
       "version": "5.0.0-FINGERROOT",
       "resolved": "https://registry.npmjs.org/@rsksmart/rsk-precompiled-abis/-/rsk-precompiled-abis-5.0.0-FINGERROOT.tgz",
       "integrity": "sha512-mKaKicuEzyLqQgnWZOBfyjdzMGjdGDqcGWkH4jXK7Edd8u62np0B7GUJLoXjHFDP6G28A/HqROx1tlGoJJcQ4Q=="
+    },
+    "node_modules/@scure/base": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.5.tgz",
+      "integrity": "sha512-Brj9FiG2W1MRQSTB212YVPRrcbjkv48FoZi/u4l/zds/ieRrqsh7aUf6CLwkAq61oKXr/ZlTzlY66gLIj3TFTQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.3.3.tgz",
+      "integrity": "sha512-LJaN3HwRbfQK0X1xFSi0Q9amqOgzQnnDngIt+ZlsBC3Bm7/nE7K0kwshZHyaru79yIVRv/e1mQAjZyuZG6jOFQ==",
+      "dev": true,
+      "dependencies": {
+        "@noble/curves": "~1.3.0",
+        "@noble/hashes": "~1.3.2",
+        "@scure/base": "~1.1.4"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.2.2.tgz",
+      "integrity": "sha512-HYf9TUXG80beW+hGAt3TRM8wU6pQoYur9iNypTROm42dorCGmLnFe3eWjz3gOq6G62H2WRh0FCzAR1PI+29zIA==",
+      "dev": true,
+      "dependencies": {
+        "@noble/hashes": "~1.3.2",
+        "@scure/base": "~1.1.4"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
@@ -1179,9 +1337,9 @@
       }
     },
     "node_modules/@types/bn.js": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.1.tgz",
-      "integrity": "sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.5.tgz",
+      "integrity": "sha512-V46N0zwKRF5Q00AZ6hWtN0T8gGmDUaUzLWQvHFo5yThtVwK/VCenFY3wXVbOvNfajEpsTfQM4IN9k/d6gUVX3A==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -1200,9 +1358,9 @@
       }
     },
     "node_modules/@types/http-cache-semantics": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
-      "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
+      "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
       "dev": true
     },
     "node_modules/@types/keyv": {
@@ -1221,27 +1379,27 @@
       "dev": true
     },
     "node_modules/@types/pbkdf2": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
-      "integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.2.tgz",
+      "integrity": "sha512-uRwJqmiXmh9++aSu1VNEn3iIxWOhd8AHXNSdlaLfdAAdSTY9jYVeGWnzejM3dvrkbqE3/hyQkQQ29IFATEGlew==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/responselike": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
-      "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/secp256k1": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.3.tgz",
-      "integrity": "sha512-Da66lEIFeIz9ltsdMZcpQvmrmmoqrfju8pm1BH8WbYjZSwUgCwXLb9C+9XYogwBITnbsSaMdVPb2ekf7TV+03w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.6.tgz",
+      "integrity": "sha512-hHxJU6PAEUn0TP4S/ZOzuTUvJWuZ6eIKeNKb5RBpODvSl6hp1Wrw4s7ATY50rklRCScUDpHzVA/DQdSjJ3UoYQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -1441,10 +1599,13 @@
       "dev": true
     },
     "node_modules/available-typed-arrays": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
       "dev": true,
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -1512,9 +1673,9 @@
       }
     },
     "node_modules/bignumber.js": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
-      "integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
       "dev": true,
       "engines": {
         "node": "*"
@@ -1722,9 +1883,9 @@
       "dev": true
     },
     "node_modules/bufferutil": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.7.tgz",
-      "integrity": "sha512-kukuqc39WOHtdxtw4UScxF/WVnMFVSQVKhtx3AjZJzhd0RGZZldcrfSEbVsWWe6KNH253574cq5F+wpv0G9pJw==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.8.tgz",
+      "integrity": "sha512-4T53u4PdgsXqKaIctwF8ifXlRTTmEPJ8iEPWFdGZvcf7sbwYo6FKFEX9eNNAnzFZ7EzJAQ3CJeOtCRA4rDp7Pw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -1810,13 +1971,19 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
       "dev": true,
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2197,9 +2364,9 @@
       }
     },
     "node_modules/cross-fetch": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
-      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
       "dev": true,
       "dependencies": {
         "node-fetch": "^2.6.12"
@@ -2351,6 +2518,23 @@
         "node": ">=10"
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -2480,15 +2664,37 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.2.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es5-ext": {
-      "version": "0.10.62",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
+      "version": "0.10.64",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
+      "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.3",
+        "esniff": "^2.0.1",
         "next-tick": "^1.1.0"
       },
       "engines": {
@@ -2771,6 +2977,27 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
+    "node_modules/esniff": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
+      "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+      "dev": true,
+      "dependencies": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.62",
+        "event-emitter": "^0.3.5",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esniff/node_modules/type": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==",
+      "dev": true
+    },
     "node_modules/espree": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
@@ -2916,26 +3143,15 @@
       }
     },
     "node_modules/ethereum-cryptography": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-2.1.3.tgz",
+      "integrity": "sha512-BlwbIL7/P45W8FGW2r7LGuvoEZ+7PWsniMvQ4p5s2xCyw9tmaDlpfsN9HjAucbF+t/qpVHwZUisgfK24TCW8aA==",
       "dev": true,
       "dependencies": {
-        "@types/pbkdf2": "^3.0.0",
-        "@types/secp256k1": "^4.0.1",
-        "blakejs": "^1.1.0",
-        "browserify-aes": "^1.2.0",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "hash.js": "^1.1.7",
-        "keccak": "^3.0.0",
-        "pbkdf2": "^3.0.17",
-        "randombytes": "^2.1.0",
-        "safe-buffer": "^5.1.2",
-        "scrypt-js": "^3.0.0",
-        "secp256k1": "^4.0.1",
-        "setimmediate": "^1.0.5"
+        "@noble/curves": "1.3.0",
+        "@noble/hashes": "1.3.3",
+        "@scure/bip32": "1.3.3",
+        "@scure/bip39": "1.2.2"
       }
     },
     "node_modules/ethereumjs-util": {
@@ -2960,6 +3176,29 @@
       "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
       "dev": true
     },
+    "node_modules/ethereumjs-util/node_modules/ethereum-cryptography": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
+      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/pbkdf2": "^3.0.0",
+        "@types/secp256k1": "^4.0.1",
+        "blakejs": "^1.1.0",
+        "browserify-aes": "^1.2.0",
+        "bs58check": "^2.1.2",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "hash.js": "^1.1.7",
+        "keccak": "^3.0.0",
+        "pbkdf2": "^3.0.17",
+        "randombytes": "^2.1.0",
+        "safe-buffer": "^5.1.2",
+        "scrypt-js": "^3.0.0",
+        "secp256k1": "^4.0.1",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/ethjs-unit": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
@@ -2979,6 +3218,16 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
       "integrity": "sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==",
       "dev": true
+    },
+    "node_modules/event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+      "dev": true,
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
     },
     "node_modules/eventemitter3": {
       "version": "4.0.4",
@@ -3394,10 +3643,13 @@
       }
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
@@ -3424,24 +3676,28 @@
       }
     },
     "node_modules/get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
       "dev": true,
       "engines": {
         "node": "*"
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
-      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
       "dev": true,
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
         "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3"
+        "has-symbols": "^1.0.3",
+        "hasown": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3618,18 +3874,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
-      "dependencies": {
-        "function-bind": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3639,10 +3883,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
       "dev": true,
       "engines": {
         "node": ">= 0.4"
@@ -3664,12 +3920,12 @@
       }
     },
     "node_modules/has-tostringtag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "dev": true,
       "dependencies": {
-        "has-symbols": "^1.0.2"
+        "has-symbols": "^1.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3716,6 +3972,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.1.tgz",
+      "integrity": "sha512-1/th4MHjnwncwXsIW6QMzlvYL9kG5e/CpVvLRZe4XPa8TOUNbCELqmvhDmnkNsAjwaG4+I8gJJL0JBvTTLO9qA==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/he": {
@@ -3788,9 +4056,9 @@
       }
     },
     "node_modules/http2-wrapper": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.0.tgz",
-      "integrity": "sha512-kZB0wxMo0sh1PehyjJUWRFEd99KC5TLjZ2cULC4f9iqJBAmKQQXEICjxl5iPJRwP40dpeHFqqhm7tYCvODpqpQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
+      "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
       "dev": true,
       "dependencies": {
         "quick-lru": "^5.1.1",
@@ -4062,12 +4330,12 @@
       }
     },
     "node_modules/is-typed-array": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.12.tgz",
-      "integrity": "sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
+      "integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
       "dev": true,
       "dependencies": {
-        "which-typed-array": "^1.1.11"
+        "which-typed-array": "^1.1.14"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4390,9 +4658,9 @@
       "dev": true
     },
     "node_modules/keccak": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.3.tgz",
-      "integrity": "sha512-JZrLIAJWuZxKbCilMpNz5Vj7Vtb4scDG3dMXLOsbzBmQGyjwE61BbW7bJkfKKCShXiQZt3T6sBgALRtmd+nZaQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.4.tgz",
+      "integrity": "sha512-3vKuW0jV8J3XNTzvfyicFR5qvxrSAGl7KIhvgOu5cmWwM7tZRj3fMbj/pfIf4be7aznbc+prBWGjywox/g2Y6Q==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -4405,9 +4673,9 @@
       }
     },
     "node_modules/keyv": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
-      "integrity": "sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
       "dependencies": {
         "json-buffer": "3.0.1"
@@ -4560,6 +4828,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/micro-ftch": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/micro-ftch/-/micro-ftch-0.3.1.tgz",
+      "integrity": "sha512-/0LLxhzP0tfiR5hcQebtudP56gUurs2CLkGarnCiB/OqEyUFQ6U3paQi/tgLv0hBJYt2rnr9MNpxz4fiiugstg==",
+      "dev": true
     },
     "node_modules/mime": {
       "version": "1.6.0",
@@ -4873,9 +5147,9 @@
       "dev": true
     },
     "node_modules/node-fetch": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
-      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -4893,9 +5167,9 @@
       }
     },
     "node_modules/node-gyp-build": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
-      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.0.tgz",
+      "integrity": "sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og==",
       "dev": true,
       "bin": {
         "node-gyp-build": "bin.js",
@@ -5140,9 +5414,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
-      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
+      "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5444,6 +5718,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
+      "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/prelude-ls": {
@@ -5951,6 +6234,23 @@
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true
     },
+    "node_modules/set-function-length": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.1.tgz",
+      "integrity": "sha512-j4t6ccc+VsKwYHso+kElc5neZpjtq9EnRICFZtWyBsLojhmeF/ZBd/elqm22WJh/BziDe/SBiOeAt0m2mfLD0g==",
+      "dev": true,
+      "dependencies": {
+        "define-data-property": "^1.1.2",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.3",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
@@ -5998,14 +6298,18 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.5.tgz",
+      "integrity": "sha512-QcgiIWV4WV7qWExbN5llt6frQB/lBven9pqliLXfGPB+K9ZYXxDozp0wLkHS24kWCm+6YXH/f0HhnObZnZOBnQ==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
+        "call-bind": "^1.0.6",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.4",
+        "object-inspect": "^1.13.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6140,9 +6444,9 @@
       "dev": true
     },
     "node_modules/sshpk": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
-      "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
+      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
       "dev": true,
       "dependencies": {
         "asn1": "~0.2.3",
@@ -6767,28 +7071,28 @@
       }
     },
     "node_modules/web3": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/web3/-/web3-1.10.0.tgz",
-      "integrity": "sha512-YfKY9wSkGcM8seO+daR89oVTcbu18NsVfvOngzqMYGUU0pPSQmE57qQDvQzUeoIOHAnXEBNzrhjQJmm8ER0rng==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-1.10.4.tgz",
+      "integrity": "sha512-kgJvQZjkmjOEKimx/tJQsqWfRDPTTcBfYPa9XletxuHLpHcXdx67w8EFn5AW3eVxCutE9dTVHgGa9VYe8vgsEA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "web3-bzz": "1.10.0",
-        "web3-core": "1.10.0",
-        "web3-eth": "1.10.0",
-        "web3-eth-personal": "1.10.0",
-        "web3-net": "1.10.0",
-        "web3-shh": "1.10.0",
-        "web3-utils": "1.10.0"
+        "web3-bzz": "1.10.4",
+        "web3-core": "1.10.4",
+        "web3-eth": "1.10.4",
+        "web3-eth-personal": "1.10.4",
+        "web3-net": "1.10.4",
+        "web3-shh": "1.10.4",
+        "web3-utils": "1.10.4"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-bzz": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.10.0.tgz",
-      "integrity": "sha512-o9IR59io3pDUsXTsps5pO5hW1D5zBmg46iNc2t4j2DkaYHNdDLwk2IP9ukoM2wg47QILfPEJYzhTfkS/CcX0KA==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.10.4.tgz",
+      "integrity": "sha512-ZZ/X4sJ0Uh2teU9lAGNS8EjveEppoHNQiKlOXAjedsrdWuaMErBPdLQjXfcrYvN6WM6Su9PMsAxf3FXXZ+HwQw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -6801,56 +7105,56 @@
       }
     },
     "node_modules/web3-core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.10.0.tgz",
-      "integrity": "sha512-fWySwqy2hn3TL89w5TM8wXF1Z2Q6frQTKHWmP0ppRQorEK8NcHJRfeMiv/mQlSKoTS1F6n/nv2uyZsixFycjYQ==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.10.4.tgz",
+      "integrity": "sha512-B6elffYm81MYZDTrat7aEhnhdtVE3lDBUZft16Z8awYMZYJDbnykEbJVS+l3mnA7AQTnSDr/1MjWofGDLBJPww==",
       "dev": true,
       "dependencies": {
         "@types/bn.js": "^5.1.1",
         "@types/node": "^12.12.6",
         "bignumber.js": "^9.0.0",
-        "web3-core-helpers": "1.10.0",
-        "web3-core-method": "1.10.0",
-        "web3-core-requestmanager": "1.10.0",
-        "web3-utils": "1.10.0"
+        "web3-core-helpers": "1.10.4",
+        "web3-core-method": "1.10.4",
+        "web3-core-requestmanager": "1.10.4",
+        "web3-utils": "1.10.4"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-core-helpers": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.10.0.tgz",
-      "integrity": "sha512-pIxAzFDS5vnbXvfvLSpaA1tfRykAe9adw43YCKsEYQwH0gCLL0kMLkaCX3q+Q8EVmAh+e1jWL/nl9U0de1+++g==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.10.4.tgz",
+      "integrity": "sha512-r+L5ylA17JlD1vwS8rjhWr0qg7zVoVMDvWhajWA5r5+USdh91jRUYosp19Kd1m2vE034v7Dfqe1xYRoH2zvG0g==",
       "dev": true,
       "dependencies": {
-        "web3-eth-iban": "1.10.0",
-        "web3-utils": "1.10.0"
+        "web3-eth-iban": "1.10.4",
+        "web3-utils": "1.10.4"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-core-method": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.10.0.tgz",
-      "integrity": "sha512-4R700jTLAMKDMhQ+nsVfIXvH6IGJlJzGisIfMKWAIswH31h5AZz7uDUW2YctI+HrYd+5uOAlS4OJeeT9bIpvkA==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.10.4.tgz",
+      "integrity": "sha512-uZTb7flr+Xl6LaDsyTeE2L1TylokCJwTDrIVfIfnrGmnwLc6bmTWCCrm71sSrQ0hqs6vp/MKbQYIYqUN0J8WyA==",
       "dev": true,
       "dependencies": {
         "@ethersproject/transactions": "^5.6.2",
-        "web3-core-helpers": "1.10.0",
-        "web3-core-promievent": "1.10.0",
-        "web3-core-subscriptions": "1.10.0",
-        "web3-utils": "1.10.0"
+        "web3-core-helpers": "1.10.4",
+        "web3-core-promievent": "1.10.4",
+        "web3-core-subscriptions": "1.10.4",
+        "web3-utils": "1.10.4"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-core-promievent": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.10.0.tgz",
-      "integrity": "sha512-68N7k5LWL5R38xRaKFrTFT2pm2jBNFaM4GioS00YjAKXRQ3KjmhijOMG3TICz6Aa5+6GDWYelDNx21YAeZ4YTg==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.10.4.tgz",
+      "integrity": "sha512-2de5WnJQ72YcIhYwV/jHLc4/cWJnznuoGTJGD29ncFQHAfwW/MItHFSVKPPA5v8AhJe+r6y4Y12EKvZKjQVBvQ==",
       "dev": true,
       "dependencies": {
         "eventemitter3": "4.0.4"
@@ -6860,86 +7164,86 @@
       }
     },
     "node_modules/web3-core-requestmanager": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.10.0.tgz",
-      "integrity": "sha512-3z/JKE++Os62APml4dvBM+GAuId4h3L9ckUrj7ebEtS2AR0ixyQPbrBodgL91Sv7j7cQ3Y+hllaluqjguxvSaQ==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.10.4.tgz",
+      "integrity": "sha512-vqP6pKH8RrhT/2MoaU+DY/OsYK9h7HmEBNCdoMj+4ZwujQtw/Mq2JifjwsJ7gits7Q+HWJwx8q6WmQoVZAWugg==",
       "dev": true,
       "dependencies": {
         "util": "^0.12.5",
-        "web3-core-helpers": "1.10.0",
-        "web3-providers-http": "1.10.0",
-        "web3-providers-ipc": "1.10.0",
-        "web3-providers-ws": "1.10.0"
+        "web3-core-helpers": "1.10.4",
+        "web3-providers-http": "1.10.4",
+        "web3-providers-ipc": "1.10.4",
+        "web3-providers-ws": "1.10.4"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-core-subscriptions": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.10.0.tgz",
-      "integrity": "sha512-HGm1PbDqsxejI075gxBc5OSkwymilRWZufIy9zEpnWKNmfbuv5FfHgW1/chtJP6aP3Uq2vHkvTDl3smQBb8l+g==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.10.4.tgz",
+      "integrity": "sha512-o0lSQo/N/f7/L76C0HV63+S54loXiE9fUPfHFcTtpJRQNDBVsSDdWRdePbWwR206XlsBqD5VHApck1//jEafTw==",
       "dev": true,
       "dependencies": {
         "eventemitter3": "4.0.4",
-        "web3-core-helpers": "1.10.0"
+        "web3-core-helpers": "1.10.4"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-eth": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.10.0.tgz",
-      "integrity": "sha512-Z5vT6slNMLPKuwRyKGbqeGYC87OAy8bOblaqRTgg94CXcn/mmqU7iPIlG4506YdcdK3x6cfEDG7B6w+jRxypKA==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.10.4.tgz",
+      "integrity": "sha512-Sql2kYKmgt+T/cgvg7b9ce24uLS7xbFrxE4kuuor1zSCGrjhTJ5rRNG8gTJUkAJGKJc7KgnWmgW+cOfMBPUDSA==",
       "dev": true,
       "dependencies": {
-        "web3-core": "1.10.0",
-        "web3-core-helpers": "1.10.0",
-        "web3-core-method": "1.10.0",
-        "web3-core-subscriptions": "1.10.0",
-        "web3-eth-abi": "1.10.0",
-        "web3-eth-accounts": "1.10.0",
-        "web3-eth-contract": "1.10.0",
-        "web3-eth-ens": "1.10.0",
-        "web3-eth-iban": "1.10.0",
-        "web3-eth-personal": "1.10.0",
-        "web3-net": "1.10.0",
-        "web3-utils": "1.10.0"
+        "web3-core": "1.10.4",
+        "web3-core-helpers": "1.10.4",
+        "web3-core-method": "1.10.4",
+        "web3-core-subscriptions": "1.10.4",
+        "web3-eth-abi": "1.10.4",
+        "web3-eth-accounts": "1.10.4",
+        "web3-eth-contract": "1.10.4",
+        "web3-eth-ens": "1.10.4",
+        "web3-eth-iban": "1.10.4",
+        "web3-eth-personal": "1.10.4",
+        "web3-net": "1.10.4",
+        "web3-utils": "1.10.4"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-eth-abi": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.10.0.tgz",
-      "integrity": "sha512-cwS+qRBWpJ43aI9L3JS88QYPfFcSJJ3XapxOQ4j40v6mk7ATpA8CVK1vGTzpihNlOfMVRBkR95oAj7oL6aiDOg==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.10.4.tgz",
+      "integrity": "sha512-cZ0q65eJIkd/jyOlQPDjr8X4fU6CRL1eWgdLwbWEpo++MPU/2P4PFk5ZLAdye9T5Sdp+MomePPJ/gHjLMj2VfQ==",
       "dev": true,
       "dependencies": {
         "@ethersproject/abi": "^5.6.3",
-        "web3-utils": "1.10.0"
+        "web3-utils": "1.10.4"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-eth-accounts": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.10.0.tgz",
-      "integrity": "sha512-wiq39Uc3mOI8rw24wE2n15hboLE0E9BsQLdlmsL4Zua9diDS6B5abXG0XhFcoNsXIGMWXVZz4TOq3u4EdpXF/Q==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.10.4.tgz",
+      "integrity": "sha512-ysy5sVTg9snYS7tJjxVoQAH6DTOTkRGR8emEVCWNGLGiB9txj+qDvSeT0izjurS/g7D5xlMAgrEHLK1Vi6I3yg==",
       "dev": true,
       "dependencies": {
-        "@ethereumjs/common": "2.5.0",
-        "@ethereumjs/tx": "3.3.2",
+        "@ethereumjs/common": "2.6.5",
+        "@ethereumjs/tx": "3.5.2",
+        "@ethereumjs/util": "^8.1.0",
         "eth-lib": "0.2.8",
-        "ethereumjs-util": "^7.1.5",
         "scrypt-js": "^3.0.1",
         "uuid": "^9.0.0",
-        "web3-core": "1.10.0",
-        "web3-core-helpers": "1.10.0",
-        "web3-core-method": "1.10.0",
-        "web3-utils": "1.10.0"
+        "web3-core": "1.10.4",
+        "web3-core-helpers": "1.10.4",
+        "web3-core-method": "1.10.4",
+        "web3-utils": "1.10.4"
       },
       "engines": {
         "node": ">=8.0.0"
@@ -6957,60 +7261,64 @@
       }
     },
     "node_modules/web3-eth-accounts/node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
         "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/web3-eth-contract": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.10.0.tgz",
-      "integrity": "sha512-MIC5FOzP/+2evDksQQ/dpcXhSqa/2hFNytdl/x61IeWxhh6vlFeSjq0YVTAyIzdjwnL7nEmZpjfI6y6/Ufhy7w==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.10.4.tgz",
+      "integrity": "sha512-Q8PfolOJ4eV9TvnTj1TGdZ4RarpSLmHnUnzVxZ/6/NiTfe4maJz99R0ISgwZkntLhLRtw0C7LRJuklzGYCNN3A==",
       "dev": true,
       "dependencies": {
         "@types/bn.js": "^5.1.1",
-        "web3-core": "1.10.0",
-        "web3-core-helpers": "1.10.0",
-        "web3-core-method": "1.10.0",
-        "web3-core-promievent": "1.10.0",
-        "web3-core-subscriptions": "1.10.0",
-        "web3-eth-abi": "1.10.0",
-        "web3-utils": "1.10.0"
+        "web3-core": "1.10.4",
+        "web3-core-helpers": "1.10.4",
+        "web3-core-method": "1.10.4",
+        "web3-core-promievent": "1.10.4",
+        "web3-core-subscriptions": "1.10.4",
+        "web3-eth-abi": "1.10.4",
+        "web3-utils": "1.10.4"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-eth-ens": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.10.0.tgz",
-      "integrity": "sha512-3hpGgzX3qjgxNAmqdrC2YUQMTfnZbs4GeLEmy8aCWziVwogbuqQZ+Gzdfrym45eOZodk+lmXyLuAdqkNlvkc1g==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.10.4.tgz",
+      "integrity": "sha512-LLrvxuFeVooRVZ9e5T6OWKVflHPFgrVjJ/jtisRWcmI7KN/b64+D/wJzXqgmp6CNsMQcE7rpmf4CQmJCrTdsgg==",
       "dev": true,
       "dependencies": {
         "content-hash": "^2.5.2",
         "eth-ens-namehash": "2.0.8",
-        "web3-core": "1.10.0",
-        "web3-core-helpers": "1.10.0",
-        "web3-core-promievent": "1.10.0",
-        "web3-eth-abi": "1.10.0",
-        "web3-eth-contract": "1.10.0",
-        "web3-utils": "1.10.0"
+        "web3-core": "1.10.4",
+        "web3-core-helpers": "1.10.4",
+        "web3-core-promievent": "1.10.4",
+        "web3-eth-abi": "1.10.4",
+        "web3-eth-contract": "1.10.4",
+        "web3-utils": "1.10.4"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-eth-iban": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.10.0.tgz",
-      "integrity": "sha512-0l+SP3IGhInw7Q20LY3IVafYEuufo4Dn75jAHT7c2aDJsIolvf2Lc6ugHkBajlwUneGfbRQs/ccYPQ9JeMUbrg==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.10.4.tgz",
+      "integrity": "sha512-0gE5iNmOkmtBmbKH2aTodeompnNE8jEyvwFJ6s/AF6jkw9ky9Op9cqfzS56AYAbrqEFuClsqB/AoRves7LDELw==",
       "dev": true,
       "dependencies": {
         "bn.js": "^5.2.1",
-        "web3-utils": "1.10.0"
+        "web3-utils": "1.10.4"
       },
       "engines": {
         "node": ">=8.0.0"
@@ -7023,72 +7331,72 @@
       "dev": true
     },
     "node_modules/web3-eth-personal": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.10.0.tgz",
-      "integrity": "sha512-anseKn98w/d703eWq52uNuZi7GhQeVjTC5/svrBWEKob0WZ5kPdo+EZoFN0sp5a5ubbrk/E0xSl1/M5yORMtpg==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.10.4.tgz",
+      "integrity": "sha512-BRa/hs6jU1hKHz+AC/YkM71RP3f0Yci1dPk4paOic53R4ZZG4MgwKRkJhgt3/GPuPliwS46f/i5A7fEGBT4F9w==",
       "dev": true,
       "dependencies": {
         "@types/node": "^12.12.6",
-        "web3-core": "1.10.0",
-        "web3-core-helpers": "1.10.0",
-        "web3-core-method": "1.10.0",
-        "web3-net": "1.10.0",
-        "web3-utils": "1.10.0"
+        "web3-core": "1.10.4",
+        "web3-core-helpers": "1.10.4",
+        "web3-core-method": "1.10.4",
+        "web3-net": "1.10.4",
+        "web3-utils": "1.10.4"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-net": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.10.0.tgz",
-      "integrity": "sha512-NLH/N3IshYWASpxk4/18Ge6n60GEvWBVeM8inx2dmZJVmRI6SJIlUxbL8jySgiTn3MMZlhbdvrGo8fpUW7a1GA==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.10.4.tgz",
+      "integrity": "sha512-mKINnhOOnZ4koA+yV2OT5s5ztVjIx7IY9a03w6s+yao/BUn+Luuty0/keNemZxTr1E8Ehvtn28vbOtW7Ids+Ow==",
       "dev": true,
       "dependencies": {
-        "web3-core": "1.10.0",
-        "web3-core-method": "1.10.0",
-        "web3-utils": "1.10.0"
+        "web3-core": "1.10.4",
+        "web3-core-method": "1.10.4",
+        "web3-utils": "1.10.4"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-providers-http": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.10.0.tgz",
-      "integrity": "sha512-eNr965YB8a9mLiNrkjAWNAPXgmQWfpBfkkn7tpEFlghfww0u3I0tktMZiaToJVcL2+Xq+81cxbkpeWJ5XQDwOA==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.10.4.tgz",
+      "integrity": "sha512-m2P5Idc8hdiO0l60O6DSCPw0kw64Zgi0pMjbEFRmxKIck2Py57RQMu4bxvkxJwkF06SlGaEQF8rFZBmuX7aagQ==",
       "dev": true,
       "dependencies": {
-        "abortcontroller-polyfill": "^1.7.3",
-        "cross-fetch": "^3.1.4",
+        "abortcontroller-polyfill": "^1.7.5",
+        "cross-fetch": "^4.0.0",
         "es6-promise": "^4.2.8",
-        "web3-core-helpers": "1.10.0"
+        "web3-core-helpers": "1.10.4"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-providers-ipc": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.10.0.tgz",
-      "integrity": "sha512-OfXG1aWN8L1OUqppshzq8YISkWrYHaATW9H8eh0p89TlWMc1KZOL9vttBuaBEi96D/n0eYDn2trzt22bqHWfXA==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.10.4.tgz",
+      "integrity": "sha512-YRF/bpQk9z3WwjT+A6FI/GmWRCASgd+gC0si7f9zbBWLXjwzYAKG73bQBaFRAHex1hl4CVcM5WUMaQXf3Opeuw==",
       "dev": true,
       "dependencies": {
         "oboe": "2.1.5",
-        "web3-core-helpers": "1.10.0"
+        "web3-core-helpers": "1.10.4"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-providers-ws": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.10.0.tgz",
-      "integrity": "sha512-sK0fNcglW36yD5xjnjtSGBnEtf59cbw4vZzJ+CmOWIKGIR96mP5l684g0WD0Eo+f4NQc2anWWXG74lRc9OVMCQ==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.10.4.tgz",
+      "integrity": "sha512-j3FBMifyuFFmUIPVQR4pj+t5ILhAexAui0opgcpu9R5LxQrLRUZxHSnU+YO25UycSOa/NAX8A+qkqZNpcFAlxA==",
       "dev": true,
       "dependencies": {
         "eventemitter3": "4.0.4",
-        "web3-core-helpers": "1.10.0",
+        "web3-core-helpers": "1.10.4",
         "websocket": "^1.0.32"
       },
       "engines": {
@@ -7096,30 +7404,31 @@
       }
     },
     "node_modules/web3-shh": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.10.0.tgz",
-      "integrity": "sha512-uNUUuNsO2AjX41GJARV9zJibs11eq6HtOe6Wr0FtRUcj8SN6nHeYIzwstAvJ4fXA53gRqFMTxdntHEt9aXVjpg==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.10.4.tgz",
+      "integrity": "sha512-cOH6iFFM71lCNwSQrC3niqDXagMqrdfFW85hC9PFUrAr3PUrIem8TNstTc3xna2bwZeWG6OBy99xSIhBvyIACw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "web3-core": "1.10.0",
-        "web3-core-method": "1.10.0",
-        "web3-core-subscriptions": "1.10.0",
-        "web3-net": "1.10.0"
+        "web3-core": "1.10.4",
+        "web3-core-method": "1.10.4",
+        "web3-core-subscriptions": "1.10.4",
+        "web3-net": "1.10.4"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-utils": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.10.0.tgz",
-      "integrity": "sha512-kSaCM0uMcZTNUSmn5vMEhlo02RObGNRRCkdX0V9UTAU0+lrvn0HSaudyCo6CQzuXUsnuY2ERJGCGPfeWmv19Rg==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.10.4.tgz",
+      "integrity": "sha512-tsu8FiKJLk2PzhDl9fXbGUWTkkVXYhtTA+SmEFkKft+9BgwLxfCRpU96sWv7ICC8zixBNd3JURVoiR3dUXgP8A==",
       "dev": true,
       "dependencies": {
+        "@ethereumjs/util": "^8.1.0",
         "bn.js": "^5.2.1",
         "ethereum-bloom-filters": "^1.0.6",
-        "ethereumjs-util": "^7.1.0",
+        "ethereum-cryptography": "^2.1.2",
         "ethjs-unit": "0.1.6",
         "number-to-bn": "1.7.0",
         "randombytes": "^2.1.0",
@@ -7205,16 +7514,16 @@
       "dev": true
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.11.tgz",
-      "integrity": "sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.14.tgz",
+      "integrity": "sha512-VnXFiIW8yNn9kIHN88xvZ4yOWchftKDsRJ8fEPacX/wl1lOvBrhsJ/OeJCXq7B0AaijRuqgzSKalJoPk+D8MPg==",
       "dev": true,
       "dependencies": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
+        "available-typed-arrays": "^1.0.6",
+        "call-bind": "^1.0.5",
         "for-each": "^0.3.3",
         "gopd": "^1.0.1",
-        "has-tostringtag": "^1.0.0"
+        "has-tostringtag": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/bridge-transaction-parser",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "A tool to find interactions with the Bridge on Rootstock",
   "main": "index.js",
   "scripts": {

--- a/tool/pegout-tracker/cli-pegout-tracker.js
+++ b/tool/pegout-tracker/cli-pegout-tracker.js
@@ -9,6 +9,8 @@ const getParsedParams = () => {
             params.pegoutTxHash = param.slice(param.indexOf('=') + 1);
         } else if(param.startsWith('--network')) {
             params.network = param.slice(param.indexOf('=') + 1);
+        } else if(param.startsWith('--requiredConfirmations')) {
+            params.requiredConfirmations = param.slice(param.indexOf('=') + 1);
         } 
         return params;
     }, {});
@@ -61,4 +63,6 @@ pegoutTracker.on(PEGOUT_TRACKER_EVENTS.pegoutStagesFound, bridgeTxDetails => {
     console.info(util.inspect(bridgeTxDetails, {depth: null, colors: true}));
 });
 
-pegoutTracker.trackPegout(pegoutTxHash, network);
+const options = params.requiredConfirmations ? { requiredConfirmations: params.requiredConfirmations } : {};
+
+pegoutTracker.trackPegout(pegoutTxHash, network, options);

--- a/tool/pegout-tracker/cli-pegout-tracker.js
+++ b/tool/pegout-tracker/cli-pegout-tracker.js
@@ -1,0 +1,64 @@
+const util = require('util');
+const PegoutTracker = require('./pegout-tracker');
+const { PEGOUT_TRACKER_EVENTS } = require('./pegout-tracker-utils');
+
+const getParsedParams = () => {
+    const params = process.argv.filter(param => param.startsWith('--'))
+    .reduce((params, param) => {
+        if(param.startsWith('--pegoutTxHash')) {
+            params.pegoutTxHash = param.slice(param.indexOf('=') + 1);
+        } else if(param.startsWith('--network')) {
+            params.network = param.slice(param.indexOf('=') + 1);
+        } 
+        return params;
+    }, {});
+    return params;
+};
+
+const params = getParsedParams();
+
+const pegoutTracker = new PegoutTracker();
+
+const { pegoutTxHash, network } = params;
+
+pegoutTracker.on(PEGOUT_TRACKER_EVENTS.releaseRequestRejectedEventFound, bridgeTxDetails => {
+    console.info('Pegout stage 1 (pegout request rejected) transaction found: ');
+    console.info(util.inspect(bridgeTxDetails, {depth: null, colors: true}));
+});
+
+pegoutTracker.on(PEGOUT_TRACKER_EVENTS.releaseRequestReceivedEventFound, bridgeTxDetails => {
+    console.info('Pegout stage 1 (pegout request) transaction found: ');
+    console.info(util.inspect(bridgeTxDetails, {depth: null, colors: true}));
+});
+
+pegoutTracker.on(PEGOUT_TRACKER_EVENTS.releaseRequestedEventFound, bridgeTxDetails => {
+    console.info('Pegout stage 2 (pegout created) transaction found: ');
+    console.info(util.inspect(bridgeTxDetails, {depth: null, colors: true}));
+});
+
+pegoutTracker.on(PEGOUT_TRACKER_EVENTS.batchPegoutCreatedEventFound, bridgeTxDetails => {
+    console.info('Pegout stage 2 (batch pegout created) transaction found: ');
+    console.info(util.inspect(bridgeTxDetails, {depth: null, colors: true}));
+});
+
+pegoutTracker.on(PEGOUT_TRACKER_EVENTS.pegoutConfirmedEventFound, bridgeTxDetails => {
+    console.info('Pegout stage 3 (confirmations) transaction found: ');
+    console.info(util.inspect(bridgeTxDetails, {depth: null, colors: true}));
+});
+
+pegoutTracker.on(PEGOUT_TRACKER_EVENTS.addSignatureEventFound, bridgeTxDetails => {
+    console.info('Pegout stage 4 (signatures) transaction found: ');
+    console.info(util.inspect(bridgeTxDetails, {depth: null, colors: true}));
+});
+
+pegoutTracker.on(PEGOUT_TRACKER_EVENTS.releaseBtcEventFound, bridgeTxDetails => {
+    console.info('Pegout stage 4 (release) transaction found: ');
+    console.info(util.inspect(bridgeTxDetails, {depth: null, colors: true}));
+});
+
+pegoutTracker.on(PEGOUT_TRACKER_EVENTS.pegoutStagesFound, bridgeTxDetails => {
+    console.info('pegoutStagesFound: ')
+    console.info(util.inspect(bridgeTxDetails, {depth: null, colors: true}));
+});
+
+pegoutTracker.trackPegout(pegoutTxHash, network);

--- a/tool/pegout-tracker/pegout-tracker-utils.js
+++ b/tool/pegout-tracker/pegout-tracker-utils.js
@@ -1,0 +1,20 @@
+const PEGOUT_TRACKER_EVENTS = {
+    releaseRequestRejectedEventFound: 'releaseRequestRejectedEventFound',
+    releaseRequestReceivedEventFound: 'releaseRequetReceivedEventFound',
+    releaseRequestedEventFound: 'releaseRequestedEventFound',
+    batchPegoutCreatedEventFound: 'batchPegoutCreatedEventFound',
+    pegoutConfirmedEventFound: 'pegoutConfirmedEventFound',
+    addSignatureEventFound: 'addSignatureEventFound',
+    releaseBtcEventFound: 'releaseBtcEventFound',
+    pegoutStagesFound: 'pegoutStagesFound',
+};
+
+const NETWORK_REQUIRED_CONFIRMATIONS = {
+    mainnet: 4000,
+    testnet: 10,
+};
+
+module.exports = {
+    PEGOUT_TRACKER_EVENTS,
+    NETWORK_REQUIRED_CONFIRMATIONS,
+};

--- a/tool/pegout-tracker/pegout-tracker-utils.js
+++ b/tool/pegout-tracker/pegout-tracker-utils.js
@@ -12,6 +12,7 @@ const PEGOUT_TRACKER_EVENTS = {
 const NETWORK_REQUIRED_CONFIRMATIONS = {
     mainnet: 4000,
     testnet: 10,
+    regtest: 3,
 };
 
 module.exports = {

--- a/tool/pegout-tracker/pegout-tracker.d.ts
+++ b/tool/pegout-tracker/pegout-tracker.d.ts
@@ -1,6 +1,10 @@
+type Options = {
+    requiredConfirmations: number;
+};
+
 type Network = 'mainnet' | 'testnet' | 'regtest';
 
 export default class PegoutTracker {
-    trackPegout(pegoutTxHash: string, network?: Network): Promise<void>;
+    trackPegout(pegoutTxHash: string, network?: Network, options?: Options): Promise<void>;
     stop(): void;
 }

--- a/tool/pegout-tracker/pegout-tracker.d.ts
+++ b/tool/pegout-tracker/pegout-tracker.d.ts
@@ -1,0 +1,10 @@
+type Options = {
+    regtestRequiredConfirmations: number;
+};
+
+type Network = 'mainnet' | 'testnet' | 'regtest';
+
+export default class PegoutTracker {
+    trackPegout(pegoutTxHash: string, network?: Network, options?: Options): Promise<void>;
+    stop(): void;
+}

--- a/tool/pegout-tracker/pegout-tracker.d.ts
+++ b/tool/pegout-tracker/pegout-tracker.d.ts
@@ -1,10 +1,6 @@
-type Options = {
-    regtestRequiredConfirmations: number;
-};
-
 type Network = 'mainnet' | 'testnet' | 'regtest';
 
 export default class PegoutTracker {
-    trackPegout(pegoutTxHash: string, network?: Network, options?: Options): Promise<void>;
+    trackPegout(pegoutTxHash: string, network?: Network): Promise<void>;
     stop(): void;
 }

--- a/tool/pegout-tracker/pegout-tracker.js
+++ b/tool/pegout-tracker/pegout-tracker.js
@@ -40,6 +40,12 @@ const checkValidTransactionHash = (txHash) => {
     }
 };
 
+const validateRequiredConfirmationsForCustomNetwork = (network, options) => {
+    if(network.startsWith('http') && !options.requiredConfirmations) {
+        throw new Error('The "requiredConfirmations" option is required for custom networks.');
+    }
+};
+
 class PegoutTracker extends EventEmitter {
 
     constructor() {
@@ -51,8 +57,9 @@ class PegoutTracker extends EventEmitter {
      * 
      * @param {string} pegoutTxHash 
      * @param {Network} network
+     * @param {Options} options
      */
-    async trackPegout(pegoutTxHash, network = 'mainnet') {
+    async trackPegout(pegoutTxHash, network = 'mainnet', options = {}) {
 
         checkValidTransactionHash(pegoutTxHash);
 
@@ -68,6 +75,8 @@ class PegoutTracker extends EventEmitter {
         const pegoutInfo = [];
 
         const networkUrl = networkParser(network);
+
+        validateRequiredConfirmationsForCustomNetwork(network, options);
 
         const rskClient = new Web3(networkUrl);
 
@@ -126,7 +135,7 @@ class PegoutTracker extends EventEmitter {
                             stage2BlockNumber = bridgeTxDetails.blockNumber;
                             stage2BtcTxHash = batchPegoutCreatedEventArguments.btcTxHash;
 
-                            const requiredConfirmations = NETWORK_REQUIRED_CONFIRMATIONS[network];
+                            const requiredConfirmations = options.requiredConfirmations ? options.requiredConfirmations : NETWORK_REQUIRED_CONFIRMATIONS[network];
 
                             const afterConfirmationBlock = stage2BlockNumber + requiredConfirmations;
 

--- a/tool/pegout-tracker/pegout-tracker.js
+++ b/tool/pegout-tracker/pegout-tracker.js
@@ -1,0 +1,175 @@
+
+const Web3 = require('web3');
+const BridgeTransactionParser = require('../../index');
+const EventEmitter = require('node:events');
+const LiveMonitor = require('../live-monitor/live-monitor');
+const { MONITOR_EVENTS } = require('../live-monitor/live-monitor-utils');
+
+const { 
+    isPegoutRequestRejectedTx,
+    isPegoutRequestReceivedTx,
+    isPegoutCreatedTx,
+    isPegoutConfirmedTx,
+    isAddSignatureTx,
+    isReleaseBtcTx,
+    getBridgeStorageValueDecodedToNumber,
+    bridgeStateKeysToStorageIndexMap,
+    getBridgeStorageAtBlock,
+} = require('../../utils');
+const networkParser = require('../network-parser');
+
+const {
+    PEGOUT_TRACKER_EVENTS,
+    NETWORK_REQUIRED_CONFIRMATIONS,
+} = require('./pegout-tracker-utils');
+
+const defaultLiveMonitorParamsValues = {
+    pegout: true,
+    network: 'https://public-node.rsk.co/',
+    checkEveryMilliseconds: 100,
+    retryOnError: true,
+    retryOnErrorAttempts: 3,
+};
+
+class PegoutTracker extends EventEmitter {
+
+    constructor() {
+        super();
+        this.started = false;
+    }
+
+    /**
+     * 
+     * @param {string} pegoutTxHash 
+     * @param {mainnet | testnet} network 
+     */
+    async trackPegout(pegoutTxHash, network = 'mainnet') {
+
+        if(!pegoutTxHash) {
+            throw new Error('pegoutTxHash is required');
+        }
+
+        if(this.started) {
+            console.warn(`Pegout tracker is already started. Stop before calling ${trackPegout.name} again. Ignoring...`);
+            return;
+        }
+
+        this.started = true;
+
+        pegoutTxHash = pegoutTxHash.toLowerCase();
+
+        const pegoutInfo = [];
+
+        const networkUrl = networkParser(network);
+
+        const rskClient = new Web3(networkUrl);
+
+        const bridgeTransactionParser = new BridgeTransactionParser(rskClient);
+        
+        const rskTx = await bridgeTransactionParser.getBridgeTransactionByTxHash(pegoutTxHash);
+
+        if(isPegoutRequestRejectedTx(rskTx)) {
+            this.emit(PEGOUT_TRACKER_EVENTS.releaseRequestRejectedEventFound, rskTx);
+            return;
+        }
+
+        if(!isPegoutRequestReceivedTx(rskTx)) {
+            throw new Error(`Transaction ${pegoutTxHash} is not a release request received transaction`);
+        }
+
+        pegoutInfo.push(rskTx);
+
+        this.emit(PEGOUT_TRACKER_EVENTS.releaseRequestReceivedEventFound, rskTx);
+
+        const nextPegoutCreationHeightRlpEncoded = await getBridgeStorageAtBlock(rskClient, bridgeStateKeysToStorageIndexMap.nextPegoutHeight.bytes, rskTx.blockNumber);
+        const nextPegoutCreationHeight = getBridgeStorageValueDecodedToNumber(nextPegoutCreationHeightRlpEncoded);
+
+        const latestBlockNumber = await rskClient.eth.getBlockNumber();
+
+        if(nextPegoutCreationHeight > latestBlockNumber) {
+            throw new Error(`Next pegout creation height ${nextPegoutCreationHeight} is greater than latest block number ${latestBlockNumber}`);
+        }
+
+        const params = { ...defaultLiveMonitorParamsValues, network: networkUrl, fromBlock: nextPegoutCreationHeight };
+
+        let stage = 2;
+
+        const liveMonitor = new LiveMonitor(params);
+
+        let stage2TxHash;
+        let stage2BlockNumber;
+        let stage2BtcTxHash;
+
+        this.on('stop', () => {
+            liveMonitor.stop();
+            this.started = false;
+        });
+
+        liveMonitor.on(MONITOR_EVENTS.filterMatched, async bridgeTxDetails => {
+            switch(stage) {
+                case 2:
+                    if(isPegoutCreatedTx(bridgeTxDetails)) {
+                        const batchPegoutCreatedEventArguments = bridgeTxDetails.events[2].arguments;
+                        if(batchPegoutCreatedEventArguments.releaseRskTxHashes.includes(pegoutTxHash.slice(2))) {
+                            stage = 3;
+                            pegoutInfo.push(bridgeTxDetails);
+                            stage2TxHash = bridgeTxDetails.txHash;
+                            stage2BlockNumber = bridgeTxDetails.blockNumber;
+                            stage2BtcTxHash = batchPegoutCreatedEventArguments.btcTxHash;
+
+                            const afterConfirmationBlock = stage2BlockNumber + NETWORK_REQUIRED_CONFIRMATIONS[network];
+
+                            const latestBlockNumber = await rskClient.eth.getBlockNumber();
+
+                            if(afterConfirmationBlock > latestBlockNumber) {
+                                throw new Error(`Expected after confirmation height ${afterConfirmationBlock} is greater than latest block number ${latestBlockNumber}`);
+                            }
+
+                            const newParams = { ...params, fromBlock: stage2BlockNumber + NETWORK_REQUIRED_CONFIRMATIONS[network] };
+                            liveMonitor.reset(newParams);
+                            this.emit(PEGOUT_TRACKER_EVENTS.releaseRequestedEventFound, bridgeTxDetails);
+                        }
+                    }
+                    break;
+                case 3:
+                    if(isPegoutConfirmedTx(bridgeTxDetails)) {
+                        const pegoutConfirmedEventArguments = bridgeTxDetails.events[1].arguments;
+                        if(pegoutConfirmedEventArguments.btcTxHash === stage2BtcTxHash) {
+                            stage = 4;
+                            pegoutInfo.push(bridgeTxDetails);
+                            this.emit(PEGOUT_TRACKER_EVENTS.pegoutConfirmedEventFound, bridgeTxDetails);
+                        }
+                    }
+                    break;
+                case 4:
+                    if(isAddSignatureTx(bridgeTxDetails)) {
+                        const pegoutAddSignatureEventArguments = bridgeTxDetails.events[0].arguments;
+                        if(pegoutAddSignatureEventArguments.releaseRskTxHash === stage2TxHash) {
+                            pegoutInfo.push(bridgeTxDetails);
+                            this.emit(PEGOUT_TRACKER_EVENTS.addSignatureEventFound, bridgeTxDetails);
+                        }
+                    } else if(isReleaseBtcTx(bridgeTxDetails)) {
+                        const pegoutReleaseBtcEventArguments = bridgeTxDetails.events[1].arguments;
+                        if(pegoutReleaseBtcEventArguments.releaseRskTxHash === stage2TxHash) {
+                            pegoutInfo.push(bridgeTxDetails);
+                            this.emit(PEGOUT_TRACKER_EVENTS.releaseBtcEventFound, bridgeTxDetails);
+                            this.emit(PEGOUT_TRACKER_EVENTS.pegoutStagesFound, pegoutInfo);
+                            this.started = false;
+                            liveMonitor.stop();
+                        }
+                    }
+                    break;
+            }
+        });
+
+        liveMonitor.start(params);
+
+    }
+
+    stop() {
+        this.emit('stop');
+    }
+
+}
+
+module.exports = PegoutTracker;

--- a/tool/pegout-tracker/pegout-tracker.js
+++ b/tool/pegout-tracker/pegout-tracker.js
@@ -31,6 +31,15 @@ const defaultLiveMonitorParamsValues = {
     retryOnErrorAttempts: 3,
 };
 
+const checkValidTransactionHash = (txHash) => {
+    if(!(typeof txHash === 'string')) {
+        throw new Error('The transaction hash is required and has to be a string.');
+    }
+    if(txHash.length !== 66 || !txHash.startsWith('0x')) {
+        throw new Error(`The transaction hash has to be 66 characters long, including the 0x prefix. "${txHash}" given.`);
+    }
+};
+
 class PegoutTracker extends EventEmitter {
 
     constructor() {
@@ -41,14 +50,11 @@ class PegoutTracker extends EventEmitter {
     /**
      * 
      * @param {string} pegoutTxHash 
-     * @param {Network} network 
-     * @param {Option} options
+     * @param {Network} network
      */
-    async trackPegout(pegoutTxHash, network = 'mainnet', options = {}) {
+    async trackPegout(pegoutTxHash, network = 'mainnet') {
 
-        if(!pegoutTxHash) {
-            throw new Error('pegoutTxHash is required');
-        }
+        checkValidTransactionHash(pegoutTxHash);
 
         if(this.started) {
             console.warn(`Pegout tracker is already started. Stop before calling ${trackPegout.name} again. Ignoring...`);

--- a/utils.js
+++ b/utils.js
@@ -1,6 +1,8 @@
 const RLP = require('rlp');
 const Bridge = require('@rsksmart/rsk-precompiled-abis').bridge;
 
+const wait = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+
 const verifyHashOrBlockNumber = (blockHashOrBlockNumber) => {
     if (typeof blockHashOrBlockNumber === 'string' &&
         blockHashOrBlockNumber.indexOf('0x') === 0 &&
@@ -109,4 +111,5 @@ module.exports = {
     isReleaseBtcTx,
     bridgeStateKeysToStorageIndexMap,
     getBridgeStorageAtBlock,
+    wait,
 };

--- a/utils.js
+++ b/utils.js
@@ -67,11 +67,11 @@ const getBridgeStorageValueDecodedToNumber = (bridgeStorageValueEncodedAsRlp) =>
 };
 
 const isPegoutRequestRejectedTx = (tx) => {
-    return tx && tx.method === '' && tx.events.length === 1 && tx.events[0].name === PEGOUT_EVENTS.release_request_rejected;
+    return tx && (tx.method === '' || tx.method.name === 'releaseBtc') && tx.events.length === 1 && tx.events[0].name === PEGOUT_EVENTS.release_request_rejected;
 };
 
 const isPegoutRequestReceivedTx = (tx) => {
-    return tx && tx.method === '' && tx.events.length === 1 && tx.events[0].name === PEGOUT_EVENTS.release_request_received;
+    return tx && (tx.method === '' || tx.method.name === 'releaseBtc') && tx.events.length === 1 && tx.events[0].name === PEGOUT_EVENTS.release_request_received;
 };
 
 const isPegoutCreatedTx = (tx) => {

--- a/utils.js
+++ b/utils.js
@@ -1,13 +1,112 @@
+const RLP = require('rlp');
+const Bridge = require('@rsksmart/rsk-precompiled-abis').bridge;
+
 const verifyHashOrBlockNumber = (blockHashOrBlockNumber) => {
-    if (typeof blockHashOrBlockNumber === "string" &&
-        blockHashOrBlockNumber.indexOf("0x") === 0 &&
+    if (typeof blockHashOrBlockNumber === 'string' &&
+        blockHashOrBlockNumber.indexOf('0x') === 0 &&
         blockHashOrBlockNumber.length !== 66) {
         throw new Error('Hash must be of length 66 starting with "0x"');
     } else if (isNaN(blockHashOrBlockNumber) || blockHashOrBlockNumber <= 0) {
-        throw new Error("Block number must be greater than 0");
+        throw new Error('Block number must be greater than 0');
     }
+};
+
+const bridgeStateKeysToStorageIndexMap = {
+    newFederationBtcUTXOs: { label: 'newFederationBtcUTXOs', bytes: '0x00000000000000000000006e657746656465726174696f6e4274635554584f73' },
+    oldFederationBtcUTXOs: { label: 'oldFederationBtcUTXOs', bytes: '0x00000000000000000000006f6c6446656465726174696f6e4274635554584f73' },
+    releaseRequestQueue: { label: 'pegoutRequests', bytes: '0x0000000000000000000000000072656c65617365526571756573745175657565'},
+    releaseRequestQueueWithTxHash: { label: 'pegoutRequests', bytes: '0x00000072656c6561736552657175657374517565756557697468547848617368'},
+    releaseTransactionSet: { label: 'pegoutsWaitingForConfirmations', bytes: '0x000000000000000000000072656c656173655472616e73616374696f6e536574' }, // 
+    releaseTransactionSetWithTxHash: { label: 'pegoutsWaitingForConfirmations', bytes: '0x0072656c656173655472616e73616374696f6e53657457697468547848617368' },
+    rskTxsWaitingFS: { label: 'pegoutsWaitingForSignatures', bytes: '0x000000000000000000000000000000000072736b54787357616974696e674653'},
+    lockingCap: { label: 'lockingCap', bytes: '0x000000000000000000000000000000000000000000006c6f636b696e67436170' },
+    nextPegoutHeight: { label: 'nextPegoutHeight', bytes: '0x000000000000000000000000000000006e6578745065676f7574486569676874' },
+    newFederation: { label: 'newFederation', bytes: '0x000000000000000000000000000000000000006e657746656465726174696f6e' },
+};
+
+const PEGOUT_EVENTS = {
+    release_request_rejected: 'release_request_rejected',
+    release_request_received: 'release_request_received',
+    release_requested: 'release_requested',
+    batch_pegout_created: 'batch_pegout_created',
+    pegout_confirmed: 'pegout_confirmed',
+    add_signature: 'add_signature',
+    release_btc: 'release_btc',
+};
+
+const removeEmptyLeftBytes = (storageValue) => {
+    return `0x${storageValue.replaceAll(/^0x0+/g, '')}`;
+};
+
+const bytesToHexString = (bytes) => {
+    return bytes.reduce((str, byte) => str + byte.toString(16).padStart(2, '0'), '');
+};
+
+const decodeRlp = (rlpEncoded) => {
+    const uint8ArrayDecoded = RLP.decode(rlpEncoded);
+    const bytesStr = bytesToHexString(uint8ArrayDecoded);
+    return bytesStr;
+};
+
+const bytesStrToNumber = (bytesStr) => {
+    return parseInt(bytesStr, 16);
+};
+
+const  getBridgeStorageValueDecodedHexString = (bridgeStorageValueEncodedAsRlp, append0xPrefix = true) => {
+    const rlpBytesWithoutEmptyBytes = removeEmptyLeftBytes(bridgeStorageValueEncodedAsRlp);
+    const decodedHexFromRlp = decodeRlp(rlpBytesWithoutEmptyBytes);
+    return append0xPrefix ? `0x${decodedHexFromRlp}` : decodedHexFromRlp;
+};
+
+const getBridgeStorageValueDecodedToNumber = (bridgeStorageValueEncodedAsRlp) => {
+    const rlpBytesWithoutEmptyBytes = removeEmptyLeftBytes(bridgeStorageValueEncodedAsRlp);
+    const decodedHexFromRlp = decodeRlp(rlpBytesWithoutEmptyBytes);
+    return bytesStrToNumber(decodedHexFromRlp);
+};
+
+const isPegoutRequestRejectedTx = (tx) => {
+    return tx && tx.method === '' && tx.events.length === 1 && tx.events[0].name === PEGOUT_EVENTS.release_request_rejected;
+};
+
+const isPegoutRequestReceivedTx = (tx) => {
+    return tx && tx.method === '' && tx.events.length === 1 && tx.events[0].name === PEGOUT_EVENTS.release_request_received;
+};
+
+const isPegoutCreatedTx = (tx) => {
+    return tx && tx.method.name === 'updateCollections' && tx.events.length === 3 && tx.events[1].name === PEGOUT_EVENTS.release_requested;
+};
+
+const isPegoutConfirmedTx = (tx) => {
+    return tx && tx.method.name === 'updateCollections' && tx.events.length === 2 && tx.events[1].name === PEGOUT_EVENTS.pegout_confirmed;
+};
+
+const isAddSignatureTx = (tx) => {
+    return tx && tx.method.name === 'addSignature' && tx.events.length === 1 && tx.events[0].name === PEGOUT_EVENTS.add_signature;
+};
+
+const isReleaseBtcTx = (tx) => {
+    return tx && tx.method.name === 'addSignature' && tx.events.length === 2 && tx.events[1].name === PEGOUT_EVENTS.release_btc;
+};
+
+const getBridgeStorageAtBlock = async (web3, storageKey, atBlock) => {
+    const result = await web3.eth.getStorageAt(Bridge.address, storageKey, atBlock);
+    return result;
 };
 
 module.exports = {
     verifyHashOrBlockNumber,
+    removeEmptyLeftBytes,
+    bytesToHexString,
+    decodeRlp,
+    bytesStrToNumber,
+    getBridgeStorageValueDecodedHexString,
+    getBridgeStorageValueDecodedToNumber,
+    isPegoutRequestRejectedTx,
+    isPegoutRequestReceivedTx,
+    isPegoutCreatedTx,
+    isPegoutConfirmedTx,
+    isAddSignatureTx,
+    isReleaseBtcTx,
+    bridgeStateKeysToStorageIndexMap,
+    getBridgeStorageAtBlock,
 };


### PR DESCRIPTION
* Adds the pegout tracker tool, an efficient way to get all the pegout related info for a given pegout transaction hash and network. It skips blocks where there's no data related to the given pegout, so it can find a pegout history in a few seconds.