### PR TITLE
Handle missing transaction receipts in getBridgeTransactionByTxHash

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -60,9 +60,9 @@ export default class BridgeTransactionParser {
     /**
      * Gets a Single Bridge Transaction Via The Transaction Hash.
      * @param transactionHash The transaction hash.
-     * @returns Object - A transaction object
+     * @returns Object - A transaction object, or undefined if the transaction receipt is not found or the transaction is not a Bridge transaction
      */
-    getBridgeTransactionByTxHash(transactionHash: string): Promise<Transaction>;
+    getBridgeTransactionByTxHash(transactionHash: string): Promise<Transaction | undefined>;
 
     /**
      * Gets a Bridge Transaction given a transaction request: TransactionRequest and a bridgeTxReceipt: TransactionReceipt.

--- a/index.js
+++ b/index.js
@@ -22,7 +22,11 @@ class BridgeTransactionParser {
         let transaction;
         const txReceipt = await this.rskClient.getTransactionReceipt(
             transactionHash);
-        if (txReceipt?.to === Bridge.address) {
+        if (!txReceipt) {
+            console.warn(`Transaction receipt not found for hash ${transactionHash}`);
+            return transaction;
+        }
+        if (txReceipt.to === Bridge.address) {
             const tx = await this.rskClient.getTransaction(
                 txReceipt.hash);
             transaction = await this.createBridgeTx(tx, txReceipt);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -43,6 +43,12 @@ describe('Get Bridge transaction by tx hash', () => {
         await expect(bridgeTransactionParser.getBridgeTransactionByTxHash(txReceipt.hash)).to.be.empty;
     });
 
+    it('Should return empty when transaction receipt is not found', async () => {
+        const transactionHash = '0x0000000000000000000000000000000000000000000000000000000000000001';
+
+        await expect(bridgeTransactionParser.getBridgeTransactionByTxHash(transactionHash)).to.be.empty;
+    });
+
     it('Should verify and return Bridge transaction from tx hash', async () => {
         const txReceipt = txReceiptsStub[4];
         const block = await rskClient.getBlock(txReceipt.blockNumber);


### PR DESCRIPTION
Split the optional-chaining check into explicit branches with logging, document that the method can return undefined, and add test coverage for the missing-receipt case.