### PR TITLE
Update npm workflow and bump version to 2.2.0

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
 
       - name: Node & Npm Version

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: "Check file existence"
         id: check_files
@@ -27,7 +29,7 @@ jobs:
           
       - name: File exists
         if: steps.check_files.outputs.files_exists != 'true'
-        # Only runs if all of the files exists
+        # Fail if required files are missing
         run: |
           echo "ERROR: Required files (package.json, README.md) are missing!"
           exit 1
@@ -61,7 +63,7 @@ jobs:
         run: |
           echo "ERROR: Package version '${{ steps.get_package_info.outputs.PACKAGE_VERSION }}' does not match GitHub tag '${{ github.ref }}'"
           exit 1
-      
+
       - name: Check if package repository matches with repository
         if: github.repositoryUrl != steps.get_package_info.outputs.PACKAGE_REPOSITORY
         # Fail if package repository doesn't match with repository
@@ -73,16 +75,14 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-          cache: 'npm'
+          cache: npm
           registry-url: https://registry.npmjs.org
-
-      - name: Clean install dependencies
-        run: |
-          rm -rf dist
-          npm ci
 
       - name: Install npm
         run: npm install -g npm@11.11.0
+
+      - name: Clean install dependencies
+        run: npm ci
 
       - name: Run tests
         run: npm test
@@ -94,7 +94,7 @@ jobs:
           PRE_UPLOAD_HASH=$(npm pack --dry-run 2>&1 | grep 'shasum:' | awk '{print $NF}')
           echo "PRE_UPLOAD_HASH=$PRE_UPLOAD_HASH" >> $GITHUB_OUTPUT
           echo "PRE_UPLOAD_HASH: $PRE_UPLOAD_HASH"
-        
+
       - name: Check if version is already published
         run: |
           PACKAGE_NAME=$(cat package.json | jq -r .name)
@@ -105,17 +105,16 @@ jobs:
             exit 1
           fi
 
-          echo "Version $PACKAGE_VERSION of $PACKAGE_NAME is not published. Proceeding with publishing..."
+          echo "Version ${PACKAGE_VERSION} of ${PACKAGE_NAME} is not published. Proceeding with publishing..."
 
       - name: Upload package
-        run: npm publish
-      
+        run: npm publish --provenance
+
       - name: Post upload validation
         id: unpack
         run: |
-          # Get the package name and version
-          PACKAGE_NAME=$(cat package.json | jq -r .name)
-          PACKAGE_VERSION=$(cat package.json | jq -r .version)
+          PACKAGE_NAME=$(jq -r .name package.json)
+          PACKAGE_VERSION=$(jq -r .version package.json)
           FULL_PACKAGE_NAME="${PACKAGE_NAME}@${PACKAGE_VERSION}"
 
           # Wait for package propagation
@@ -134,7 +133,7 @@ jobs:
           echo "POST_UPLOAD_HASH: '${{ steps.unpack.outputs.POST_UPLOAD_HASH }}'"
 
           if [ "${{ steps.pack.outputs.PRE_UPLOAD_HASH }}" != "${{ steps.unpack.outputs.POST_UPLOAD_HASH }}" ]; then
-            echo "Hash mismatch detected!"
+            echo "Hash mismatch detected! The version may already be on npm; investigate before re-publishing."
             exit 1
           fi
           echo "Hashes match successfully!"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -2,7 +2,7 @@ name: Deploy packages on NPM
 
 on:
   release:
-    types: [created, edited, published]
+    types: [published]
 
 # Declare default permissions as read only.
 permissions: read-all
@@ -57,7 +57,7 @@ jobs:
 
       - name: Check if package version matches with tag
         if: github.ref != steps.get_package_info.outputs.PACKAGE_VERSION
-        # Fail if package version not properly setted
+        # Fail if package version not properly set
         run: |
           echo "ERROR: Package version '${{ steps.get_package_info.outputs.PACKAGE_VERSION }}' does not match GitHub tag '${{ github.ref }}'"
           exit 1
@@ -72,7 +72,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22
+          node-version: 24
           cache: 'npm'
           registry-url: https://registry.npmjs.org
 
@@ -81,8 +81,8 @@ jobs:
           rm -rf dist
           npm ci
 
-      - name: Update npm
-        run: npm install -g npm@latest
+      - name: Install npm
+        run: npm install -g npm@11.11.0
 
       - name: Run tests
         run: npm test
@@ -102,7 +102,7 @@ jobs:
 
           if npm view $PACKAGE_NAME@$PACKAGE_VERSION > /dev/null 2>&1; then
             echo "Version $PACKAGE_VERSION of $PACKAGE_NAME is already published."
-            exit 0
+            exit 1
           fi
 
           echo "Version $PACKAGE_VERSION of $PACKAGE_NAME is not published. Proceeding with publishing..."
@@ -138,4 +138,3 @@ jobs:
             exit 1
           fi
           echo "Hashes match successfully!"
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rsksmart/bridge-transaction-parser",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rsksmart/bridge-transaction-parser",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "MIT",
       "dependencies": {
         "@rsksmart/rsk-precompiled-abis": "9.0.0-VETIVER",
@@ -966,9 +966,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.32",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
-      "integrity": "sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==",
+      "version": "2.10.33",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.33.tgz",
+      "integrity": "sha512-bA6+tcSLpz2tIEdDXZPpPTIuxBcC4+w6SieaYyfigIa4h8GlFxbA17v22Vx3JUtuZQj9SgOsnbK+aTBzyDyEuw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1403,9 +1403,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.364",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.364.tgz",
-      "integrity": "sha512-G/dYE3+AYhyHwzTwg8UbnXf7zqMERYh7l2jJ3QujhFsH8agSYwtnGAR2aZ7f0AakIKJXd5En/Hre4igIUrdlYw==",
+      "version": "1.5.365",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.365.tgz",
+      "integrity": "sha512-xfip4u1QF1s+URFqpA6N+OeFpDGpN7VJz1f3MO3bVL0QYBjpGiZ5/Of7kugvM+o8TTqmanUlviHN3c8M9vYWCw==",
       "dev": true,
       "license": "ISC"
     },
@@ -2258,10 +2258,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -2525,9 +2535,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.46",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
-      "integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
   "name": "@rsksmart/bridge-transaction-parser",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rsksmart/bridge-transaction-parser",
-      "version": "2.1.2",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@rsksmart/rsk-precompiled-abis": "9.0.0-VETIVER",
         "ethers": "6.16.0"
       },
       "devDependencies": {
-        "chai": "4.5.0",
-        "chai-as-promised": "7.1.1",
+        "chai": "6.2.2",
+        "chai-as-promised": "8.0.2",
         "mocha": "11.7.6",
         "nyc": "18.0.0",
         "rewire": "9.0.1",
@@ -778,16 +778,6 @@
         "type-detect": "4.0.8"
       }
     },
-    "node_modules/@sinonjs/commons/node_modules/type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@sinonjs/fake-timers": {
       "version": "15.4.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
@@ -807,6 +797,16 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.1",
         "type-detect": "^4.1.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@types/estree": {
@@ -948,16 +948,6 @@
       "dev": true,
       "license": "Python-2.0"
     },
-    "node_modules/assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1087,35 +1077,26 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/chai": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
-      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.3",
-        "deep-eql": "^4.1.3",
-        "get-func-name": "^2.0.2",
-        "loupe": "^2.3.6",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.1.0"
-      },
       "engines": {
-        "node": ">=4"
+        "node": ">=18"
       }
     },
     "node_modules/chai-as-promised": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
-      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-8.0.2.tgz",
+      "integrity": "sha512-1GadL+sEJVLzDjcawPM4kjfnL+p/9vrxiEUonowKOAzvVg0PixJUdtuDzdkDeQhK3zfOE76GqGkZIQ7/Adcrqw==",
       "dev": true,
-      "license": "WTFPL",
+      "license": "MIT",
       "dependencies": {
-        "check-error": "^1.0.2"
+        "check-error": "^2.1.1"
       },
       "peerDependencies": {
-        "chai": ">= 2.1.2 < 5"
+        "chai": ">= 2.1.2 < 7"
       }
     },
     "node_modules/chalk": {
@@ -1149,16 +1130,13 @@
       }
     },
     "node_modules/check-error": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
-      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "get-func-name": "^2.0.2"
-      },
       "engines": {
-        "node": "*"
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -1347,19 +1325,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/deep-eql": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
-      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "type-detect": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -1822,16 +1787,6 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/get-func-name": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
-      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/get-package-type": {
@@ -2396,16 +2351,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/loupe": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
-      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-func-name": "^2.0.1"
       }
     },
     "node_modules/lru-cache": {
@@ -3001,16 +2946,6 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/pathval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -3743,9 +3678,9 @@
       }
     },
     "node_modules/type-detect": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
-      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@rsksmart/bridge-transaction-parser",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "A tool to find and decode transactions to the Rootstock Bridge",
   "main": "index.js",
   "scripts": {
-    "test": "nyc mocha --timeout 10000"
+    "test": "nyc mocha --timeout 10000 --require test/setup-chai.cjs"
   },
   "repository": {
     "type": "git",
@@ -29,8 +29,8 @@
     "powpeg"
   ],
   "devDependencies": {
-    "chai": "4.5.0",
-    "chai-as-promised": "7.1.1",
+    "chai": "6.2.2",
+    "chai-as-promised": "8.0.2",
     "mocha": "11.7.6",
     "nyc": "18.0.0",
     "rewire": "9.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/bridge-transaction-parser",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "A tool to find and decode transactions to the Rootstock Bridge",
   "main": "index.js",
   "scripts": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,11 +1,8 @@
-const chai = require('chai')
-const chaiAsPromised = require('chai-as-promised');
+const chai = require('chai');
 const BridgeTransactionParser = require('../index');
 const {txReceiptsStub, blocksStub} = require("./blockchain-stubs.util");
 const { rskClient } = require("./ethers-js-stub.util");
-const assert = chai.assert;
-chai.use(chaiAsPromised);
-const {expect} = chai;
+const { assert, expect } = chai;
 
 describe('Constructor', () => {
 

--- a/test/setup-chai.cjs
+++ b/test/setup-chai.cjs
@@ -1,0 +1,8 @@
+const chai = require('chai');
+
+exports.mochaHooks = {
+  async beforeAll() {
+    const { default: chaiAsPromised } = await import('chai-as-promised');
+    chai.use(chaiAsPromised);
+  },
+};


### PR DESCRIPTION
This pull request updates the Node.js and npm versions used in CI workflows, improves the npm publishing workflow for reliability and provenance, and updates test setup and dependencies to support newer versions of `chai` and `chai-as-promised`. It also bumps the package version to `2.2.0` and ensures tests are properly configured with required hooks.

**CI/CD and Workflow Improvements:**

* Updated Node.js version from 22 to 24 in both `.github/workflows/build-test.yml` and `.github/workflows/publish-npm.yml` for better compatibility and security. [[1]](diffhunk://#diff-063ca77e012f959eba648db60e6868875fd1e70e5f5ac081193d848f8d61ef32L20-R20) [[2]](diffhunk://#diff-f089b0e55b389f533faf1e65e3cb93b0bcd97b391c32f28449d08fd4f0512447L75-R85)
* Improved the npm publish workflow to only trigger on `published` releases, set `persist-credentials: false` for checkout, and clarified error messages. [[1]](diffhunk://#diff-f089b0e55b389f533faf1e65e3cb93b0bcd97b391c32f28449d08fd4f0512447L5-R5) [[2]](diffhunk://#diff-f089b0e55b389f533faf1e65e3cb93b0bcd97b391c32f28449d08fd4f0512447R21-R22) [[3]](diffhunk://#diff-f089b0e55b389f533faf1e65e3cb93b0bcd97b391c32f28449d08fd4f0512447L30-R32) [[4]](diffhunk://#diff-f089b0e55b389f533faf1e65e3cb93b0bcd97b391c32f28449d08fd4f0512447L60-R62)
* Ensured that the workflow fails if the package version is already published, and uses `npm publish --provenance` for enhanced package traceability.
* Improved hash mismatch messaging to guide investigation if a package version appears to already exist on npm.

**Dependency and Test Setup Updates:**

* Upgraded `chai` to 6.2.2 and `chai-as-promised` to 8.0.2, and refactored test setup to use a new `test/setup-chai.cjs` file with proper hooks for async plugin loading. Updated test command to require this setup file. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L32-R33) [[2]](diffhunk://#diff-31429d483e2a25805fd24f038c52eaab8b23d7ba9845ccac1f4f7aa986d6cbb7R1-R8) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R7) [[4]](diffhunk://#diff-af95cb6f5f65fe70216ddce70325e785438d5aaff956a0666ebf46ef6402f526L1-R5)

**Version Bump:**

* Bumped package version to `2.2.0` in `package.json`.